### PR TITLE
Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,19 @@ var objectType = new minim.ObjectType()
   .set('email', 'john@example.com')
   .set('id', 4)
 ```
+
+### Errors
+
+Minim has its own error type that is passed down through the call chain. This allows clients to write chains that may break but do not throw JavaScript errors.
+
+```javascript
+var objectExample = {
+  foo: {
+    bar: 'value 1'
+  }
+};
+
+var objectType = minim.ObjectType(objectExample);
+var value1 = objectType.get('foo').get('bar'); // value of foo.bar
+var notFound = objectType.get('baz').get('foo') // Returns error object
+```

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -27,8 +27,30 @@ class ElementType
 
   set: (@content) -> @
 
+  getProperty: -> new ErrorType 'Element does not have method getProperty', @
+
+  has: -> new ErrorType 'Element does not have method has', @
+
+  map: -> new ErrorType 'Element does not have method map', @
+
+  filter: -> new ErrorType 'Element does not have method filter', @
+
+  forEach: -> new ErrorType 'Element does not have method forEach', @
+
+  length: -> new ErrorType 'Element does not have method length', @
+
+  push: -> new ErrorType 'Element does not have method push', @
+
+  add: -> new ErrorType 'Element does not have method add', @
+
+  find: -> new ErrorType 'Element does not have method find', @
+
+  keys: -> new ErrorType 'Element does not have method keys', @
+
+  values: -> new ErrorType 'Element does not have method values', @
+
 class ErrorType
-  constructor: (@message = 'Unspecified error') ->
+  constructor: (@message = 'Unspecified error', @element) ->
 
   elementType: -> 'error'
 
@@ -53,6 +75,10 @@ class ErrorType
   add: -> @
 
   find: -> @
+
+  keys: -> @
+
+  values: -> @
 
 class NullType extends ElementType
   constructor: (attributes) ->
@@ -213,6 +239,7 @@ convertFromDom = (el) ->
   new NullType().fromDom el
 
 module.exports = {
+  ElementType
   ErrorType
   NullType
   StringType

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -27,6 +27,33 @@ class ElementType
 
   set: (@content) -> @
 
+class ErrorType
+  constructor: (@message = 'Unspecified error') ->
+
+  elementType: -> 'error'
+
+  get: -> @
+
+  set: -> @
+
+  getProperty: -> @
+
+  has: -> false
+
+  map: -> @
+
+  filter: -> @
+
+  forEach: -> @
+
+  length: -> @
+
+  push: -> @
+
+  add: -> @
+
+  find: -> @
+
 class NullType extends ElementType
   constructor: (attributes) ->
     super 'null', null, attributes
@@ -186,6 +213,7 @@ convertFromDom = (el) ->
   new NullType().fromDom el
 
 module.exports = {
+  ErrorType
   NullType
   StringType
   NumberType

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -139,12 +139,15 @@ class Item extends Collection
       results
     , {}
 
-  get: (name) ->
-    return @ unless name?
+  getProperty: (name) ->
     _.first(@content.filter (val) -> val.attributes.name is name)
 
+  get: (name) ->
+    return @ unless name?
+    @getProperty(name).get()
+
   set: (name, val) ->
-    property = @get name
+    property = @getProperty name
 
     if property
       property.set val

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -29,7 +29,7 @@ class ElementType
 
   getProperty: -> new ErrorType 'Element does not have method getProperty', @
 
-  has: -> new ErrorType 'Element does not have method has', @
+  has: -> false
 
   map: -> new ErrorType 'Element does not have method map', @
 

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -115,7 +115,9 @@ class Collection extends ElementType
 
   get: (index) ->
     return @ unless index?
-    @content[index]
+    item = @content[index]
+    return new ErrorType "Index #{index} does not exist", @ unless item
+    item
 
   set: (index, val) ->
     @content[index] = convertToType val
@@ -197,7 +199,9 @@ class Item extends Collection
 
   get: (name) ->
     return @ unless name?
-    @getProperty(name).get()
+    property = @getProperty(name)
+    return new ErrorType "Property #{name} does not exist", @ unless property
+    property.get()
 
   set: (name, val) ->
     property = @getProperty name

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -54,7 +54,6 @@ class ErrorType
     try
       throw new Error @message
     catch err
-      console.log err.stack
       @err = err
 
   elementType: -> 'error'

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -88,6 +88,7 @@ class Collection extends ElementType
   findElements: (cond, results = []) ->
     @content.forEach (el) ->
       el.findElements(cond, results) if el.elementType() in ['array', 'object']
+      results.push(el.content) if el.elementType() is 'property' and cond(el.content)
       results.push(el) if cond(el)
     results
 
@@ -150,6 +151,11 @@ class Item extends Collection
     else
       @content.push new PropertyType name, val
     @
+
+  has: (name) ->
+    for property in @content
+      return true if property.attributes.name is name
+    return false
 
   keys: -> @content.map (val) -> val.attributes.name
 

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -213,9 +213,8 @@ class Item extends Collection
     @
 
   has: (name) ->
-    for property in @content
-      return true if property.attributes.name is name
-    return false
+    return true for property in @content when property.attributes.name is name
+    false
 
   keys: -> @content.map (val) -> val.attributes.name
 

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -51,6 +51,11 @@ class ElementType
 
 class ErrorType
   constructor: (@message = 'Unspecified error', @element) ->
+    try
+      throw new Error @message
+    catch err
+      console.log err.stack
+      @err = err
 
   elementType: -> 'error'
 

--- a/src/primitives.coffee
+++ b/src/primitives.coffee
@@ -54,6 +54,8 @@ class ErrorType
 
   elementType: -> 'error'
 
+  toValue: -> undefined
+
   get: -> @
 
   set: -> @

--- a/test.js
+++ b/test.js
@@ -1,8 +1,0 @@
-var minim = require('./index');
-
-var objectType = new minim.ObjectType()
-  .set('name', 'John Doe')
-  .set('email', 'john@example.com')
-  .set('id', 4)
-
-console.log(objectType.toValue());

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -546,6 +546,10 @@ describe 'Minim Primitives', ->
         it 'returns itself', ->
           expect(arrayType.get().get(0).get()).to.equal 'a'
 
+      context 'when the index does not exist', ->
+        it 'returns an error element', ->
+          expect(arrayType.get(10).elementType()).to.equal 'error'
+
     describe '#set', ->
       it 'sets the value of the array', ->
         arrayType.set(0, 'hello world')
@@ -704,6 +708,10 @@ describe 'Minim Primitives', ->
       context 'when a property name is not given', ->
         it 'returns itself', ->
           expect(objectType.get().get('foo')).to.equal 'bar'
+
+      context 'when the property name does not exist', ->
+        it 'returns an error type', ->
+          expect(objectType.get('does-not-exist').elementType()).to.equal 'error'
 
     describe '#set', ->
       it 'sets the value of the name given', ->

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -261,6 +261,10 @@ describe 'Minim Primitives', ->
       it 'is an error', ->
         expect(errType.elementType()).to.equal 'error'
 
+    describe '#toValue', ->
+      it 'returns undefined', ->
+        expect(errType.toValue()).to.be.undefined
+
     context 'when chained', ->
       it 'returns itself', ->
         expect(errType.get('foo').get(0).get('bar')).to.equal errType

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -146,6 +146,56 @@ describe 'Minim Primitives', ->
           foo: 'bar'
           z: 2
 
+  describe 'ElementType', ->
+    elType = undefined
+
+    before ->
+      elType = new minim.ElementType 'element'
+
+    describe '#getProperty', ->
+      it 'returns an error', ->
+        expect(elType.getProperty('foo').elementType()).to.equal 'error'
+
+    describe '#has', ->
+      it 'returns an error', ->
+        expect(elType.has('foo').elementType()).to.equal 'error'
+
+    describe '#map', ->
+      it 'returns an error', ->
+        expect(elType.map((el) -> 'test').elementType()).to.equal 'error'
+
+    describe '#filter', ->
+      it 'returns an error', ->
+        expect(elType.filter((el) -> true).elementType()).to.equal 'error'
+
+    describe '#forEach', ->
+      it 'returns an error', ->
+        expect(elType.forEach((el) -> console.log('test')).elementType()).to.equal 'error'
+
+    describe '#length', ->
+      it 'returns an error', ->
+        expect(elType.length().elementType()).to.equal 'error'
+
+    describe '#push', ->
+      it 'returns an error', ->
+        expect(elType.push('foo').elementType()).to.equal 'error'
+
+    describe '#add', ->
+      it 'returns an error', ->
+        expect(elType.add('add').elementType()).to.equal 'error'
+
+    describe '#find', ->
+      it 'returns an error', ->
+        expect(elType.find((el) -> true).elementType()).to.equal 'error'
+
+    describe '#keys', ->
+      it 'returns an error', ->
+        expect(elType.keys().elementType()).to.equal 'error'
+
+    describe '#values', ->
+      it 'returns an error', ->
+        expect(elType.values().elementType()).to.equal 'error'
+
   describe 'ErrorType', ->
     errType = undefined
 
@@ -198,6 +248,14 @@ describe 'Minim Primitives', ->
     describe '#find', ->
       it 'returns itself', ->
         expect(errType.find((el) -> true)).to.equal errType
+
+    describe '#keys', ->
+      it 'returns itself', ->
+        expect(errType.keys()).to.equal errType
+
+    describe '#values', ->
+      it 'returns itself', ->
+        expect(errType.values()).to.equal errType
 
     describe '#elementType', ->
       it 'is an error', ->

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -202,8 +202,12 @@ describe 'Minim Primitives', ->
     before ->
       errType = new minim.ErrorType 'Error message'
 
-    it 'stores the error message', ->
-      expect(errType.message).to.equal 'Error message'
+    context 'when initializing', ->
+      it 'stores the error message', ->
+        expect(errType.message).to.equal 'Error message'
+
+      it 'stores throws an error', ->
+        expect(errType.err).to.be.instanceOf Error
 
     describe '#getProperty', ->
       it 'returns itself', ->

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -329,8 +329,17 @@ describe 'Minim Primitives', ->
                     content: 'bar'
                   }
                   {
-                    element: 'number'
-                    content: 4
+                    element: 'object'
+                    content: [
+                      {
+                        element: 'property'
+                        attributes:
+                          name: 'foo'
+                        content:
+                            element: 'string'
+                            content: 'baz'
+                      }
+                    ]
                   }
                 ]
               }
@@ -343,10 +352,10 @@ describe 'Minim Primitives', ->
         strings = doc.find (el) -> el.elementType() == 'string'
 
       it 'returns the correct number of items', ->
-        expect(strings.length()).to.equal 4
+        expect(strings.length()).to.equal 5
 
       it 'returns the correct values', ->
-        expect(strings.toValue()).to.deep.equal ['foobar', 'hello world', 'baz', 'bar']
+        expect(strings.toValue()).to.deep.equal ['foobar', 'hello world', 'baz', 'bar', 'baz']
 
   describe 'ArrayType', ->
     arrayType = undefined
@@ -585,6 +594,15 @@ describe 'Minim Primitives', ->
       it 'sets a value that has not been defined yet', ->
         objectType.set('bar', 'hello world')
         expect(objectType.get('bar').get()).to.equal 'hello world'
+
+    describe '#has', ->
+      context 'when an existing property is given', ->
+        it 'returns true', ->
+          expect(objectType.has('foo')).to.be.true
+
+      context 'when a property that does not exist is given', ->
+        it 'returns false', ->
+          expect(objectType.has('does-not-exist')).to.be.false
 
     describe '#keys', ->
       it 'gets the keys of all properties', ->

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -146,6 +146,67 @@ describe 'Minim Primitives', ->
           foo: 'bar'
           z: 2
 
+  describe 'ErrorType', ->
+    errType = undefined
+
+    before ->
+      errType = new minim.ErrorType 'Error message'
+
+    it 'stores the error message', ->
+      expect(errType.message).to.equal 'Error message'
+
+    describe '#getProperty', ->
+      it 'returns itself', ->
+        expect(errType.getProperty('foo')).to.equal errType
+
+    describe '#get', ->
+      it 'returns itself', ->
+        expect(errType.get('foo')).to.equal errType
+
+    describe '#set', ->
+      it 'returns itself', ->
+        expect(errType.set('foo')).to.equal errType
+
+    describe '#has', ->
+      it 'returns false', ->
+        expect(errType.has('foo')).to.be.false
+
+    describe '#map', ->
+      it 'returns itself', ->
+        expect(errType.map((el) -> 'test')).to.equal errType
+
+    describe '#filter', ->
+      it 'returns itself', ->
+        expect(errType.filter((el) -> true)).to.equal errType
+
+    describe '#forEach', ->
+      it 'returns itself', ->
+        expect(errType.forEach((el) -> console.log('test'))).to.equal errType
+
+    describe '#length', ->
+      it 'returns itself', ->
+        expect(errType.length()).to.equal errType
+
+    describe '#push', ->
+      it 'returns itself', ->
+        expect(errType.push('foo')).to.equal errType
+
+    describe '#add', ->
+      it 'returns itself', ->
+        expect(errType.add('add')).to.equal errType
+
+    describe '#find', ->
+      it 'returns itself', ->
+        expect(errType.find((el) -> true)).to.equal errType
+
+    describe '#elementType', ->
+      it 'is an error', ->
+        expect(errType.elementType()).to.equal 'error'
+
+    context 'when chained', ->
+      it 'returns itself', ->
+        expect(errType.get('foo').get(0).get('bar')).to.equal errType
+
   describe 'NullType', ->
     nullType = undefined
 

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -580,20 +580,20 @@ describe 'Minim Primitives', ->
     describe '#get', ->
       context 'when a property name is given', ->
         it 'returns the value of the name given', ->
-          expect(objectType.get('foo').get()).to.equal 'bar'
+          expect(objectType.get('foo')).to.equal 'bar'
 
       context 'when a property name is not given', ->
         it 'returns itself', ->
-          expect(objectType.get().get('foo').get()).to.equal 'bar'
+          expect(objectType.get().get('foo')).to.equal 'bar'
 
     describe '#set', ->
       it 'sets the value of the name given', ->
         objectType.set('foo', 'hello world')
-        expect(objectType.get('foo').get()).to.equal 'hello world'
+        expect(objectType.get('foo')).to.equal 'hello world'
 
       it 'sets a value that has not been defined yet', ->
         objectType.set('bar', 'hello world')
-        expect(objectType.get('bar').get()).to.equal 'hello world'
+        expect(objectType.get('bar')).to.equal 'hello world'
 
     describe '#has', ->
       context 'when an existing property is given', ->

--- a/test/primitives-test.coffee
+++ b/test/primitives-test.coffee
@@ -158,7 +158,7 @@ describe 'Minim Primitives', ->
 
     describe '#has', ->
       it 'returns an error', ->
-        expect(elType.has('foo').elementType()).to.equal 'error'
+        expect(elType.has('foo')).to.be.false
 
     describe '#map', ->
       it 'returns an error', ->


### PR DESCRIPTION
This PR adds a special error type that is used to allow for chains to break, but not throw JavaScript errors. This way, you can write a client to handle what may be found in an object, yet not worry if that particular chain is not there.

Edit: this becomes useful when a chain fails on filters and maps.

``` coffeescript
foo = obj.get('bar').filter((el) -> el.has('baz')).map((el) -> el.toValue())
```

If `foo` above doesn't have `bar`, the error gets passed all the way through. This means there are no JavaScript errors thrown, but rather a minim `ErrorType` object that is returned on the first `get('bar')`.
