### PR TITLE
Upgrade eslint to fix no-shadow bug

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,7 +40,7 @@
 /**
  * Variables
  */
-    "no-shadow": 1,                  // http://eslint.org/docs/rules/no-shadow
+    "no-shadow": 2,                  // http://eslint.org/docs/rules/no-shadow
     "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
     "no-unused-vars": [2, {          // http://eslint.org/docs/rules/no-unused-vars
       "vars": "local",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {
@@ -35,7 +35,7 @@
     "chai": "^1.10.0",
     "coffee-script": "^1.9.0",
     "coveralls": "^2.11.2",
-    "eslint": "^0.21.0",
+    "eslint": "^0.21.2",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.4",
     "mocha-sinon": "^1.1.4",


### PR DESCRIPTION
With the latest release of eslint and the inclusion of eslint/eslint#2545 we can now remove the technical debt from switching to a warning workaround for the `no-shadow` error.

https://github.com/eslint/eslint/releases

This is a minor change and shouldn't require a new release, but will help prevent style issues with future development.
