### PR TITLE
Subclass Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The `map` method may be used to map over an array. Each item given is a Minim in
 ```javascript
 var arrayType = new minim.ArrayType(['a', 'b', 'c']);
 var newArray = arrayType.map(function(item) {
-  return item.elementType();
+  return item.element;
 }); // newArray is now ['string', 'string', 'string']
 ```
 
@@ -293,7 +293,7 @@ The `find` method traverses the entire descendent element tree and returns an `A
 ```javascript
 var arrayType = new minim.ArrayType(['a', [1, 2], 'b', 3]);
 var numbers = arrayType.find(function(el) {
-  return el.elementType() === 'number'
+  return el.element === 'number'
 }).toValue(); // [1, 2, 3]
 ```
 
@@ -304,7 +304,7 @@ The `children` method traverses direct descendants and returns an `ArrayType` of
 ```javascript
 var arrayType = new minim.ArrayType(['a', [1, 2], 'b', 3]);
 var numbers = arrayType.children(function(el) {
-  return el.elementType() === 'number';
+  return el.element === 'number';
 }).toValue(); // [3]
 ```
 

--- a/test/primitives-test.es6
+++ b/test/primitives-test.es6
@@ -1,17 +1,46 @@
 import {expect} from './spec-helper';
 import minim from '../lib/minim';
 
-describe('Minim Primitives', function() {
-  describe('convertToType', function() {
+describe('Minim Primitives', () => {
+  describe('ElementType', () => {
+    describe('#element', () => {
+      context('when getting an element that has not been set', () => {
+        let el;
+
+        before(() => {
+          el = new minim.ElementType();
+        });
+
+        it('returns base element', () => {
+          expect(el.element).to.equal('element');
+        });
+      });
+
+      context('when setting the element', () => {
+        let el;
+
+        before(() => {
+          el = new minim.ElementType();
+          el.element = 'foobar';
+        });
+
+        it('sets the element correctly', () => {
+          expect(el.element).to.equal('foobar');
+        });
+      })
+    });
+  });
+
+  describe('convertToType', () => {
     function typeCheck(name, val) {
       let returnedType;
 
-      context('when given ' + name, function() {
-        before(function() {
+      context('when given ' + name, () => {
+        before(() => {
           returnedType = minim.convertToType(val);
         });
 
-        it('returns ' + name, function() {
+        it('returns ' + name, () => {
           expect(returnedType.element).to.equal(name);
         });
       });
@@ -27,28 +56,28 @@ describe('Minim Primitives', function() {
     });
   });
 
-  describe('convertFromType', function() {
+  describe('convertFromType', () => {
     function typeCheck(name, el) {
-      context('when given ' + name, function() {
+      context('when given ' + name, () => {
         let returnedType;
 
-        before(function() {
+        before(() => {
           returnedType = minim.convertFromRefract(el);
         });
 
-        it('returns ' + name + ' element', function() {
+        it('returns ' + name + ' element', () => {
           expect(returnedType.element).to.equal(name);
         });
 
-        it('has the correct value', function() {
+        it('has the correct value', () => {
           expect(returnedType.toValue()).to.equal(el.content);
         });
       });
 
-      context('when given compact ' + name, function() {
+      context('when given compact ' + name, () => {
         let returnedType;
 
-        before(function() {
+        before(() => {
           // NOTE: If this is ever giving you issues, remember that it
           //       does NOT handle nested long-form elements.
           returnedType = minim.convertFromCompactRefract([
@@ -56,11 +85,11 @@ describe('Minim Primitives', function() {
           ]);
         });
 
-        it('returns ' + name + ' element', function() {
+        it('returns ' + name + ' element', () => {
           expect(returnedType.element).to.equal(name);
         });
 
-        it('has the correct value', function() {
+        it('has the correct value', () => {
           expect(returnedType.toValue()).to.equal(el.content);
         });
       });
@@ -86,7 +115,7 @@ describe('Minim Primitives', function() {
       content: true
     });
 
-    context('when given array', function() {
+    context('when given array', () => {
       const el = {
         element: 'array',
         content: [
@@ -101,20 +130,20 @@ describe('Minim Primitives', function() {
       };
       let returnedType;
 
-      before(function() {
+      before(() => {
         returnedType = minim.convertFromRefract(el);
       });
 
-      it('returns array element', function() {
+      it('returns array element', () => {
         expect(returnedType.element).to.equal('array');
       });
 
-      it('has the correct values', function() {
+      it('has the correct values', () => {
         expect(returnedType.toValue()).to.deep.equal([1, 2]);
       });
     });
 
-    context('when given object', function() {
+    context('when given object', () => {
       const el = {
         element: 'object',
         content: [
@@ -135,15 +164,15 @@ describe('Minim Primitives', function() {
       };
       let returnedType;
 
-      before(function() {
+      before(() => {
         returnedType = minim.convertFromRefract(el);
       });
 
-      it('returns object element', function() {
+      it('returns object element', () => {
         expect(returnedType.element).to.equal('object');
       });
 
-      it('has the correct values', function() {
+      it('has the correct values', () => {
         expect(returnedType.toValue()).to.deep.equal({
           foo: 'bar',
           z: 2
@@ -151,26 +180,33 @@ describe('Minim Primitives', function() {
       });
     });
   });
-  describe('NullType', function() {
+
+  describe('NullType', () => {
     let nullType;
 
-    before(function() {
+    before(() => {
       nullType = new minim.NullType();
     });
 
-    describe('#elementType', function() {
-      it('is null', function() {
+    describe('#element', () => {
+      it('is null', () => {
         expect(nullType.element).to.equal('null');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns null', function() {
+    describe('#primitive', () => {
+      it('returns null as the Refract primitive', () => {
+        expect(nullType.primitive()).to.equal('null');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns null', () => {
         expect(nullType.toValue()).to.equal(null);
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'null',
         meta: {},
@@ -178,51 +214,57 @@ describe('Minim Primitives', function() {
         content: null
       };
 
-      it('returns a null DOM object', function() {
+      it('returns a null DOM object', () => {
         expect(nullType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = ['null', {}, {}, null];
-      it('returns a null Compact DOM object', function() {
+      it('returns a null Compact DOM object', () => {
         expect(nullType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      it('returns the null value', function() {
+    describe('#get', () => {
+      it('returns the null value', () => {
         expect(nullType.get()).to.equal(null);
       });
     });
 
-    describe('#set', function() {
-      it('cannot set the value', function() {
+    describe('#set', () => {
+      it('cannot set the value', () => {
         expect(nullType.set('foobar')).to.be.an.instanceof(Error);
       });
     });
   });
 
-  describe('StringType', function() {
+  describe('StringType', () => {
     let stringType;
 
-    before(function() {
+    before(() => {
       stringType = new minim.StringType('foobar');
     });
 
-    describe('#elementType', function() {
-      it('is a boolean', function() {
+    describe('#element', () => {
+      it('is a string', () => {
         expect(stringType.element).to.equal('string');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns the string', function() {
+    describe('#primitive', () => {
+      it('returns string as the Refract primitive', () => {
+        expect(stringType.primitive()).to.equal('string');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns the string', () => {
         expect(stringType.toValue()).to.equal('foobar');
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'string',
         meta: {},
@@ -230,53 +272,59 @@ describe('Minim Primitives', function() {
         content: 'foobar'
       };
 
-      it('returns a string DOM object', function() {
+      it('returns a string DOM object', () => {
         expect(stringType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = ['string', {}, {}, 'foobar'];
 
-      it('returns a string Compact DOM object', function() {
+      it('returns a string Compact DOM object', () => {
         expect(stringType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      it('returns the string value', function() {
+    describe('#get', () => {
+      it('returns the string value', () => {
         expect(stringType.get()).to.equal('foobar');
       });
     });
 
-    describe('#set', function() {
-      it('sets the value of the string', function() {
+    describe('#set', () => {
+      it('sets the value of the string', () => {
         stringType.set('hello world');
         expect(stringType.get()).to.equal('hello world');
       });
     });
   });
 
-  describe('NumberType', function() {
+  describe('NumberType', () => {
     let numberType;
 
-    before(function() {
+    before(() => {
       numberType = new minim.NumberType(4);
     });
 
-    describe('#elementType', function() {
-      it('is a boolean', function() {
+    describe('#element', () => {
+      it('is a number', () => {
         expect(numberType.element).to.equal('number');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns the number', function() {
+    describe('#primitive', () => {
+      it('returns number as the Refract primitive', () => {
+        expect(numberType.primitive()).to.equal('number');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns the number', () => {
         expect(numberType.toValue()).to.equal(4);
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'number',
         meta: {},
@@ -284,53 +332,59 @@ describe('Minim Primitives', function() {
         content: 4
       };
 
-      it('returns a number DOM object', function() {
+      it('returns a number DOM object', () => {
         expect(numberType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = ['number', {}, {}, 4];
 
-      it('returns a number Compact DOM object', function() {
+      it('returns a number Compact DOM object', () => {
         expect(numberType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      it('returns the number value', function() {
+    describe('#get', () => {
+      it('returns the number value', () => {
         expect(numberType.get()).to.equal(4);
       });
     });
 
-    describe('#set', function() {
-      it('sets the value of the number', function() {
+    describe('#set', () => {
+      it('sets the value of the number', () => {
         numberType.set(10);
         expect(numberType.get()).to.equal(10);
       });
     });
   });
 
-  describe('BoolType', function() {
+  describe('BoolType', () => {
     let boolType;
 
-    before(function() {
+    before(() => {
       boolType = new minim.BooleanType(true);
     });
 
-    describe('#elementType', function() {
-      it('is a boolean', function() {
+    describe('#element', () => {
+      it('is a boolean', () => {
         expect(boolType.element).to.equal('boolean');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns the boolean', function() {
+    describe('#primitive', () => {
+      it('returns boolean as the Refract primitive', () => {
+        expect(boolType.primitive()).to.equal('boolean');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns the boolean', () => {
         expect(boolType.toValue()).to.equal(true);
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'boolean',
         meta: {},
@@ -338,35 +392,35 @@ describe('Minim Primitives', function() {
         content: true
       };
 
-      it('returns a boolean DOM object', function() {
+      it('returns a boolean DOM object', () => {
         expect(boolType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = ['boolean', {}, {}, true];
 
-      it('returns a boolean Compact DOM object', function() {
+      it('returns a boolean Compact DOM object', () => {
         expect(boolType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      it('returns the boolean value', function() {
+    describe('#get', () => {
+      it('returns the boolean value', () => {
         expect(boolType.get()).to.equal(true);
       });
     });
 
-    describe('#set', function() {
-      it('sets the value of the boolean', function() {
+    describe('#set', () => {
+      it('sets the value of the boolean', () => {
         boolType.set(false);
         expect(boolType.get()).to.equal(false);
       });
     });
   });
 
-  describe('Collection', function() {
-    describe('searching', function() {
+  describe('Collection', () => {
+    describe('searching', () => {
       const refract = {
         element: 'array',
         content: [
@@ -404,76 +458,82 @@ describe('Minim Primitives', function() {
       let strings;
       let recursiveStrings;
 
-      before(function() {
+      before(() => {
         const doc = minim.convertFromRefract(refract);
         strings = doc.children(el => el.element === 'string');
         recursiveStrings = doc.find(el => el.element === 'string');
       });
 
-      describe('#children', function () {
-        it('returns the correct number of items', function() {
+      describe('#children', () => {
+        it('returns the correct number of items', () => {
           expect(strings.length).to.equal(2);
         });
 
-        it('returns the correct values', function() {
+        it('returns the correct values', () => {
           expect(strings.toValue()).to.deep.equal(['foobar', 'hello world']);
         });
       });
 
-      describe('#find', function () {
-        it('returns the correct number of items', function() {
+      describe('#find', () => {
+        it('returns the correct number of items', () => {
           expect(recursiveStrings.length).to.equal(4);
         });
 
-        it('returns the correct values', function() {
+        it('returns the correct values', () => {
           expect(recursiveStrings.toValue()).to.deep.equal(['foobar', 'hello world', 'baz', 'bar']);
         });
       });
     });
   });
 
-  describe('ArrayType', function() {
-    let arrayType, itAddsToArray;
+  describe('ArrayType', () => {
+    let arrayType;
 
     function setArray() {
       arrayType = new minim.ArrayType(['a', true, null, 1]);
     }
 
-    before(function() {
+    before(() => {
       setArray();
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
       setArray();
     });
 
-    describe('.content', function() {
+    describe('.content', () => {
       let correctTypes;
       let storedTypes;
 
-      before(function() {
+      before(() => {
         correctTypes = ['string', 'boolean', 'null', 'number'];
         storedTypes = arrayType.content.map(el => el.element);
       });
 
-      it('stores the correct types', function() {
+      it('stores the correct types', () => {
         expect(storedTypes).to.deep.equal(correctTypes);
       });
     });
 
-    describe('#elementType', function() {
-      it('is an array', function() {
+    describe('#element', () => {
+      it('is an array', () => {
         expect(arrayType.element).to.equal('array');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns the array', function() {
+    describe('#primitive', () => {
+      it('returns array as the Refract primitive', () => {
+        expect(arrayType.primitive()).to.equal('array');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns the array', () => {
         expect(arrayType.toValue()).to.deep.equal(['a', true, null, 1]);
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'array',
         meta: {},
@@ -503,50 +563,50 @@ describe('Minim Primitives', function() {
         ]
       };
 
-      it('returns an array DOM object', function() {
+      it('returns an array DOM object', () => {
         expect(arrayType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = ['array', {}, {}, [['string', {}, {}, 'a'], ['boolean', {}, {}, true], ['null', {}, {}, null], ['number', {}, {}, 1]]];
 
-      it('returns an array Compact DOM object', function() {
+      it('returns an array Compact DOM object', () => {
         expect(arrayType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      context('when an index is given', function() {
-        it('returns the item from the array', function() {
+    describe('#get', () => {
+      context('when an index is given', () => {
+        it('returns the item from the array', () => {
           expect(arrayType.get(0).get()).to.equal('a');
         });
       });
 
-      context('when no index is given', function() {
-        it('returns itself', function() {
+      context('when no index is given', () => {
+        it('returns itself', () => {
           expect(arrayType.get().get(0).get()).to.equal('a');
         });
       });
     });
 
-    describe('#set', function() {
-      it('sets the value of the array', function() {
+    describe('#set', () => {
+      it('sets the value of the array', () => {
         arrayType.set(0, 'hello world');
         expect(arrayType.get(0).get()).to.equal('hello world');
       });
     });
 
-    describe('#map', function() {
-      it('allows for mapping the content of the array', function() {
+    describe('#map', () => {
+      it('allows for mapping the content of the array', () => {
         const newArray = arrayType.map(item => item.get());
         expect(newArray).to.deep.equal(['a', true, null, 1]);
       });
     });
 
-    describe('#filter', function() {
-      it('allows for filtering the content', function() {
-        const newArray = arrayType.filter(function(item) {
+    describe('#filter', () => {
+      it('allows for filtering the content', () => {
+        const newArray = arrayType.filter((item) => {
           var ref;
           return (ref = item.get()) === 'a' || ref === 1;
         });
@@ -554,44 +614,44 @@ describe('Minim Primitives', function() {
       });
     });
 
-    describe('#forEach', function() {
-      it('iterates over each item', function() {
+    describe('#forEach', () => {
+      it('iterates over each item', () => {
         var results;
         results = [];
-        arrayType.forEach(function(item) {
+        arrayType.forEach((item) => {
           return results.push(item);
         });
         expect(results.length).to.equal(4);
       });
     });
 
-    describe('#length', function() {
-      it('returns the length of the content', function() {
+    describe('#length', () => {
+      it('returns the length of the content', () => {
         expect(arrayType.length).to.equal(4);
       });
     });
 
-    itAddsToArray = function(instance) {
+    function itAddsToArray(instance) {
       expect(instance.length).to.equal(5);
       expect(instance.get(4).toValue()).to.equal('foobar');
     };
 
-    describe('#push', function() {
-      it('adds a new item to the array', function() {
+    describe('#push', () => {
+      it('adds a new item to the array', () => {
         arrayType.push('foobar');
         itAddsToArray(arrayType);
       });
     });
 
-    describe('#add', function() {
-      it('adds a new item to the array', function() {
+    describe('#add', () => {
+      it('adds a new item to the array', () => {
         arrayType.add('foobar');
         itAddsToArray(arrayType);
       });
     });
 
-    describe('#[Symbol.iterator]', function () {
-      it('can be used in a for ... of loop', function () {
+    describe('#[Symbol.iterator]', () => {
+      it('can be used in a for ... of loop', () => {
         const items = [];
         for (let item of arrayType) {
           items.push(item);
@@ -602,8 +662,8 @@ describe('Minim Primitives', function() {
     });
   });
 
-  describe('ObjectType', function() {
-    let objectType, itHascollectionMethod;
+  describe('ObjectType', () => {
+    let objectType;
 
     function setObject() {
       objectType = new minim.ObjectType({
@@ -612,35 +672,41 @@ describe('Minim Primitives', function() {
       });
     }
 
-    before(function() {
+    before(() => {
       setObject();
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
       setObject();
     });
 
-    describe('.content', function() {
+    describe('.content', () => {
       let correctTypes, storedTypes;
 
-      before(function() {
+      before(() => {
         correctTypes = ['string', 'number'];
         storedTypes = objectType.content.map(el => el.element);
       });
 
-      it('has the correct types', function() {
+      it('has the correct types', () => {
         expect(storedTypes).to.deep.equal(correctTypes);
       });
     });
 
-    describe('#elementType', function() {
-      it('is a string type', function() {
+    describe('#element', () => {
+      it('is a string type', () => {
         expect(objectType.element).to.equal('object');
       });
     });
 
-    describe('#toValue', function() {
-      it('returns the object', function() {
+    describe('#primitive', () => {
+      it('returns object as the Refract primitive', () => {
+        expect(objectType.primitive()).to.equal('object');
+      });
+    });
+
+    describe('#toValue', () => {
+      it('returns the object', () => {
         expect(objectType.toValue()).to.deep.equal({
           foo: 'bar',
           z: 1
@@ -648,7 +714,7 @@ describe('Minim Primitives', function() {
       });
     });
 
-    describe('#toRefract', function() {
+    describe('#toRefract', () => {
       const expected = {
         element: 'object',
         meta: {},
@@ -672,12 +738,12 @@ describe('Minim Primitives', function() {
         ]
       };
 
-      it('returns an object DOM object', function() {
+      it('returns an object DOM object', () => {
         expect(objectType.toRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#toCompactRefract', function() {
+    describe('#toCompactRefract', () => {
       const expected = [
         'object', {}, {}, [
           [
@@ -692,51 +758,51 @@ describe('Minim Primitives', function() {
         ]
       ];
 
-      it('returns a object Compact DOM object', function() {
+      it('returns a object Compact DOM object', () => {
         expect(objectType.toCompactRefract()).to.deep.equal(expected);
       });
     });
 
-    describe('#get', function() {
-      context('when a property name is given', function() {
-        it('returns the value of the name given', function() {
+    describe('#get', () => {
+      context('when a property name is given', () => {
+        it('returns the value of the name given', () => {
           expect(objectType.get('foo').get()).to.equal('bar');
         });
       });
 
-      context('when a property name is not given', function() {
-        it('returns itself', function() {
+      context('when a property name is not given', () => {
+        it('returns itself', () => {
           expect(objectType.get().get('foo').get()).to.equal('bar');
         });
       });
     });
 
-    describe('#set', function() {
-      it('sets the value of the name given', function() {
+    describe('#set', () => {
+      it('sets the value of the name given', () => {
         objectType.set('foo', 'hello world');
         expect(objectType.get('foo').get()).to.equal('hello world');
       });
 
-      it('sets a value that has not been defined yet', function() {
+      it('sets a value that has not been defined yet', () => {
         objectType.set('bar', 'hello world');
         expect(objectType.get('bar').get()).to.equal('hello world');
       });
     });
 
-    describe('#keys', function() {
-      it('gets the keys of all properties', function() {
+    describe('#keys', () => {
+      it('gets the keys of all properties', () => {
         expect(objectType.keys()).to.deep.equal(['foo', 'z']);
       });
     });
 
-    describe('#values', function() {
-      it('gets the values of all properties', function() {
+    describe('#values', () => {
+      it('gets the values of all properties', () => {
         expect(objectType.values()).to.deep.equal(['bar', 1]);
       });
     });
 
-    describe('#items', function () {
-      it('provides a list of name/value pairs to iterate', function () {
+    describe('#items', () => {
+      it('provides a list of name/value pairs to iterate', () => {
         const keys = [];
         const values = [];
 
@@ -750,9 +816,9 @@ describe('Minim Primitives', function() {
       });
     });
 
-    itHascollectionMethod = function(method) {
-      describe('#' + method, function() {
-        it('responds to #' + method, function() {
+    function itHascollectionMethod(method) {
+      describe('#' + method, () => {
+        it('responds to #' + method, () => {
           expect(objectType).to.respondTo(method);
         });
       });
@@ -764,8 +830,8 @@ describe('Minim Primitives', function() {
     itHascollectionMethod('push');
     itHascollectionMethod('add');
 
-    describe('#[Symbol.iterator]', function () {
-      it('can be used in a for ... of loop', function () {
+    describe('#[Symbol.iterator]', () => {
+      it('can be used in a for ... of loop', () => {
         const items = [];
         for (let item of objectType) {
           items.push(item);

--- a/test/registry-test.es6
+++ b/test/registry-test.es6
@@ -41,6 +41,18 @@ describe('Minim registry', () => {
 
       expect(converted).to.equal(myType);
     });
+
+    it('should allow for roundtrip conversions', () => {
+      registry.register('foo', minim.StringType);
+
+      // Full version
+      const fullVersion = registry.fromRefract({ element: 'foo', meta: {}, attributes: {}, content: 'test' }).toRefract();
+      expect(fullVersion).to.deep.equal({ element: 'foo', meta: {}, attributes: {}, content: 'test' });
+
+      // Compact version
+      const compactValue = registry.fromCompactRefract(['foo', {}, {}, 'test']).toCompactRefract();
+      expect(compactValue).to.deep.equal(['foo', {}, {}, 'test']);
+    });
   });
 
   describe('#getElementClass', () => {

--- a/test/subclass-test.es6
+++ b/test/subclass-test.es6
@@ -5,11 +5,22 @@ describe('Minim type subclasses', () => {
   class MyType extends minim.StringType {
     constructor(...args) {
       super(...args);
-
       this.element = 'myType';
       this[minim.attributeElementKeys] = ['headers'];
     }
   }
+
+  context('when initializing', () => {
+    const myType = new MyType();
+
+    it('can overwrite the element name', () => {
+      expect(myType.element).to.equal('myType');
+    });
+
+    it('returns the correct primitive type', () => {
+      expect(myType.primitive()).to.equal('string');
+    });
+  });
 
   describe('deserializing attributes', () => {
     const myType = new MyType().fromRefract({


### PR DESCRIPTION
This adds two methods on the base element class. One is for setting the element name and the other is for `attributeElementKeys`.

Additionally, I've added a `primitive` method for knowing what primitive type the sub class came from.

When reviewing this, it is probably helpful to go through each commit one by one. We can use parts of this functionality if it's too much of a departure from our current design.
