### PR TITLE
Add a name getter on meta.

### DIFF
--- a/src/primitives.es6
+++ b/src/primitives.es6
@@ -59,6 +59,10 @@ export class Meta {
     this.setProperty('class', value);
   }
 
+  get name() {
+    return this.getProperty('name', '');
+  }
+
   set name(value) {
     this.setProperty('name', value);
   }

--- a/test/primitives-test.es6
+++ b/test/primitives-test.es6
@@ -9,7 +9,8 @@ describe('Minim Primitives', () => {
       before(() => {
         el = new minim.ElementType({}, {
           id: 'foobar',
-          class: ['a', 'b'],
+          'class': ['a', 'b'],
+          name: 'MyName',
           title: 'Title',
           description: 'Description'
         });
@@ -18,6 +19,7 @@ describe('Minim Primitives', () => {
       it('should initialize the correct meta data', () => {
         expect(el.meta.id.toValue()).to.equal('foobar');
         expect(el.meta.class.toValue()).to.deep.equal(['a', 'b']);
+        expect(el.meta.name.toValue()).to.deep.equal('MyName');
         expect(el.meta.title.toValue()).to.equal('Title');
         expect(el.meta.description.toValue()).to.equal('Description');
       });


### PR DESCRIPTION
Looks like this was partially removed in a previous commit, but the setter
was still there. What do you think of adding it back in? If not, we can just
remove the setter as well.

This is still used by HTTP headers in the resource namespace, but I can add
the getter/setter in Fury instead if no other elements will use a name in
their meta.

cc @smizell 
