### PR TITLE
Add convenience methods for meta attributes

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -160,7 +160,7 @@ var Meta = createClass({
       return this.getProperty('class', []);
     },
     set: function(element) {
-      this.setProperty('id', element);
+      this.setProperty('class', element);
     }
   },
 
@@ -305,6 +305,18 @@ BaseElement = createClass({
 
   equals: function(value) {
     return _.isEqual(this.toValue(), value);
+  },
+
+  getMetaProperty: function(name, value) {
+    if (!this.meta[name]) {
+      this.meta[name] = registry.toElement(value);
+    }
+
+    return this.meta[name];
+  },
+
+  setMetaProperty: function(name, value) {
+    this.meta[name] = registry.toElement(value);
   }
 }, {}, {
   element: {
@@ -314,6 +326,53 @@ BaseElement = createClass({
     },
     set: function(element) {
       this._storedElement = element;
+    }
+  },
+
+  // TODO: Mixin these mutator functions to share code with Meta class
+  // Subclassing causes circular redundancy
+  id: {
+    get: function() {
+      return this.getMetaProperty('id', '');
+    },
+    set: function(element) {
+      this.setMetaProperty('id', element);
+    }
+  },
+
+  class: {
+    get: function() {
+      return this.getMetaProperty('class', []);
+    },
+    set: function(element) {
+      this.setMetaProperty('class', element);
+    }
+  },
+
+  name: {
+    get: function() {
+      return this.getMetaProperty('name', '');
+    },
+    set: function(element) {
+      this.setMetaProperty('name', element);
+    }
+  },
+
+  title: {
+    get: function() {
+      return this.getMetaProperty('title', '');
+    },
+    set: function(element) {
+      this.setMetaProperty('title', element);
+    }
+  },
+
+  description: {
+    get: function() {
+      return this.getMetaProperty('description', '');
+    },
+    set: function(element) {
+      this.setMetaProperty('description', element);
     }
   }
 });

--- a/test/primitives-test.js
+++ b/test/primitives-test.js
@@ -75,6 +75,41 @@ describe('Minim Primitives', function() {
         expect(el.equals({ foo: 'baz'})).to.be.false;
       });
     });
+
+    describe('convenience methods', function() {
+      var meta = {
+        id: 'foobar',
+        'class': ['a'],
+        title: 'A Title',
+        description: 'A Description'
+      };
+
+      context('when the meta is already set', function() {
+        var el = new minim.BaseElement(null, _.clone(meta));
+
+        _.forEach(_.keys(meta), function(key) {
+          it('provides a convenience method for ' + key, function() {
+            expect(el[key].toValue()).to.deep.equal(meta[key]);
+          });
+        });
+      });
+
+      context('when meta is set with getters and setters', function() {
+        var el = new minim.BaseElement(null);
+
+        _.forEach(_.keys(meta), function(key) {
+          el[key] = meta[key];
+
+          it('works for getters and setters for ' + key, function() {
+            expect(el[key].toValue()).to.deep.equal(meta[key]);
+          });
+
+          it('stores the correct data in meta for ' + key, function() {
+            expect(el.meta[key].toValue()).to.deep.equal(meta[key])
+          });
+        });
+      });
+    });
   });
 
   describe('convertToElement', function() {


### PR DESCRIPTION
This allows you to access meta attributes with something like:

``` js
element.id
```

Instead of:

``` js
element.meta.id
```

Note: There is still more work to fix this.
1. There is a bug with this, as it still mutates `meta` #40 
2. It is not DRY, as it has copy/paste code from Meta class

I will try to address these together as I refactor how we use `meta`.
