### PR TITLE
More Find Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,14 @@ var numbers = arrayElement.find(function(el) {
 }).toValue(); // [1, 2, 3]
 ```
 
+##### findByClass
+
+The `findByClass` method traverses the entire descendent element tree and returns `ArrayElement` of all elements that match the given element name.
+
+##### findByElement
+
+The `findByElement` method traverses the entire descendent element tree and returns `ArrayElement` of all elements that match the given class.
+
 ##### children
 
 The `children` method traverses direct descendants and returns an `ArrayElement` of all elements that match the condition function given.

--- a/README.md
+++ b/README.md
@@ -294,11 +294,11 @@ var numbers = arrayElement.find(function(el) {
 
 ##### findByClass
 
-The `findByClass` method traverses the entire descendent element tree and returns `ArrayElement` of all elements that match the given element name.
+The `findByClass` method traverses the entire descendent element tree and returns an `ArrayElement` of all elements that match the given element name.
 
 ##### findByElement
 
-The `findByElement` method traverses the entire descendent element tree and returns `ArrayElement` of all elements that match the given class.
+The `findByElement` method traverses the entire descendent element tree and returns an `ArrayElement` of all elements that match the given class.
 
 ##### children
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -562,6 +562,12 @@ var Collection = BaseElement.extend({
     });
   },
 
+  findByClass: function(className) {
+    return this.find(function(item) {
+      return item.class.contains(className);
+    });
+  },
+
   /*
    * Search all direct descendents using a condition function.
    */

--- a/lib/base.js
+++ b/lib/base.js
@@ -556,6 +556,12 @@ var Collection = BaseElement.extend({
     return newArray;
   },
 
+  findByElement: function(element) {
+    return this.find(function(item) {
+      return item.element === element;
+    });
+  },
+
   /*
    * Search all direct descendents using a condition function.
    */

--- a/test/primitives-test.js
+++ b/test/primitives-test.js
@@ -599,6 +599,22 @@ describe('Minim Primitives', function() {
         });
       });
 
+      describe('#findByElement', function() {
+        var items
+
+        before(function() {
+          items = doc.findByElement('number');
+        });
+
+        it('returns the correct number of items', function() {
+          expect(items.length).to.equal(1);
+        });
+
+        it('returns the correct values', function() {
+          expect(items.toValue()).to.deep.equal([4]);
+        });
+      });
+
       describe('#first', function() {
         it('returns the first item', function() {
           expect(doc.first()).to.deep.equal(doc.content[0]);

--- a/test/primitives-test.js
+++ b/test/primitives-test.js
@@ -541,6 +541,9 @@ describe('Minim Primitives', function() {
             content: [
               {
                 element: 'string',
+                meta: {
+                  'class': ['test-class']
+                },
                 content: 'baz'
               }, {
                 element: 'boolean',
@@ -600,7 +603,7 @@ describe('Minim Primitives', function() {
       });
 
       describe('#findByElement', function() {
-        var items
+        var items;
 
         before(function() {
           items = doc.findByElement('number');
@@ -612,6 +615,22 @@ describe('Minim Primitives', function() {
 
         it('returns the correct values', function() {
           expect(items.toValue()).to.deep.equal([4]);
+        });
+      });
+
+      describe('#findByClass', function() {
+        var items;
+
+        before(function() {
+          items = doc.findByClass('test-class');
+        });
+
+        it('returns the correct number of items', function() {
+          expect(items.length).to.equal(1);
+        });
+
+        it('returns the correct values', function() {
+          expect(items.toValue()).to.deep.equal(['baz']);
         });
       });
 

--- a/test/primitives-test.js
+++ b/test/primitives-test.js
@@ -594,7 +594,7 @@ describe('Minim Primitives', function() {
 
       describe('#find', function() {
         it('returns the correct number of items', function() {
-          expect(recursiveStrings.length).to.equal(4);
+          expect(recursiveStrings).to.have.lengthOf(4);
         });
 
         it('returns the correct values', function() {
@@ -610,7 +610,7 @@ describe('Minim Primitives', function() {
         });
 
         it('returns the correct number of items', function() {
-          expect(items.length).to.equal(1);
+          expect(items).to.have.lengthOf(1);
         });
 
         it('returns the correct values', function() {
@@ -626,7 +626,7 @@ describe('Minim Primitives', function() {
         });
 
         it('returns the correct number of items', function() {
-          expect(items.length).to.equal(1);
+          expect(items).to.have.lengthOf(1);
         });
 
         it('returns the correct values', function() {


### PR DESCRIPTION
This PR introduces two new methods for finding elements. They are mostly helper methods that reuse the functionality of `find` and allow for finding all elements given an element name and all elements given a class.
