### PR TITLE
Embedded Refract

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -111,12 +111,13 @@ var ElementRegistry = createClass({
 
   fromEmbeddedRefract: function(value) {
     var element;
+    var self = this;
 
     if (_.isArray(value)) {
-      element = registry.toElement([]);
+      element = self.toElement([]);
 
       _.forEach(value, function(item) {
-        element.push(registry.fromEmbeddedRefract(item));
+        element.push(self.fromEmbeddedRefract(item));
       });
 
       return element;
@@ -124,9 +125,9 @@ var ElementRegistry = createClass({
 
     if (_.isObject(value)) {
       if (_.has(value, 'refract')) {
-        element = registry.fromRefract(value.refract);
+        element = self.fromRefract(value.refract);
       } else {
-        element = registry.toElement({});
+        element = self.toElement({});
       }
 
       // Objects get the properties of the object set as members
@@ -136,7 +137,7 @@ var ElementRegistry = createClass({
       return element;
     }
 
-    return registry.toElement(value);
+    return self.toElement(value);
   }
 });
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -159,6 +159,16 @@ BaseElement = createClass({
     return [this.element, this.meta.toValue(), attributes, this.content];
   },
 
+  toEmbeddedRefract: function() {
+    if (this.attributes.content.length === 0 && this.meta.content.length === 0) {
+      return this.toValue();
+    }
+
+    return {
+      refract: this.toRefract()
+    };
+  },
+
   /*
    * Some attributes may be elements. This is domain-specific knowledge, so
    * a subclass *MUST* define the attribute element names to convert. This
@@ -411,6 +421,18 @@ var Collection = BaseElement.extend({
       return el.toCompactRefract();
     });
     return [this.element, this.meta.toValue(), attributes, compactDoms];
+  },
+
+  toEmbeddedRefract: function() {
+    if (this.attributes.content.length === 0 && this.meta.content.length === 0) {
+      return this.map(function(item) {
+        return item.toEmbeddedRefract();
+      });
+    }
+
+    return {
+      refract: this.toRefract()
+    };
   },
 
   fromRefract: function(doc) {
@@ -824,6 +846,22 @@ var ObjectElement = Collection.extend({
     return this.content.forEach(function(item) {
       return cb(item.value, item.key, item);
     });
+  },
+
+  toEmbeddedRefract: function() {
+    if (this.attributes.content.length === 0 && this.meta.content.length === 0) {
+      var refract = {};
+
+      this.forEach(function(value, key) {
+        refract[key.toValue()] = value.toEmbeddedRefract();
+      });
+
+      return refract;
+    }
+
+    return {
+      refract: this.toRefract()
+    };
   }
 });
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -237,6 +237,13 @@ BaseElement = createClass({
     return this;
   },
 
+  fromEmbeddedRefract: function(converter, embeddedObj) {
+    var self = this;
+    _.forEach(_.keys(embeddedObj), function(key) {
+      self.attributes.set(key, converter(embeddedObj[key]));
+    });
+  },
+
   set: function(content) {
     this.content = content;
     return this;
@@ -862,6 +869,13 @@ var ObjectElement = Collection.extend({
     return {
       refract: this.toRefract()
     };
+  },
+
+  fromEmbeddedRefract: function(converter, embeddedObj) {
+    var self = this;
+    _.forEach(_.keys(embeddedObj), function(key) {
+      self.set(key, converter(embeddedObj[key]));
+    });
   }
 });
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -107,6 +107,36 @@ var ElementRegistry = createClass({
   fromCompactRefract: function(tuple) {
     var ElementClass = this.getElementClass(tuple[0]);
     return new ElementClass().fromCompactRefract(tuple);
+  },
+
+  fromEmbeddedRefract: function(value) {
+    var element;
+
+    if (_.isArray(value)) {
+      element = registry.toElement([]);
+
+      _.forEach(value, function(item) {
+        element.push(registry.fromEmbeddedRefract(item));
+      });
+
+      return element;
+    }
+
+    if (_.isObject(value)) {
+      if (_.has(value, 'refract')) {
+        element = registry.fromRefract(value.refract);
+      } else {
+        element = registry.toElement({});
+      }
+
+      // Objects get the properties of the object set as members
+      // All other get the properties set as attributes
+      element.fromEmbeddedRefract(_.omit(value, 'refract'));
+
+      return element;
+    }
+
+    return registry.toElement(value);
   }
 });
 
@@ -237,10 +267,10 @@ BaseElement = createClass({
     return this;
   },
 
-  fromEmbeddedRefract: function(converter, embeddedObj) {
+  fromEmbeddedRefract: function(embeddedObj) {
     var self = this;
     _.forEach(_.keys(embeddedObj), function(key) {
-      self.attributes.set(key, converter(embeddedObj[key]));
+      self.attributes.set(key, registry.fromEmbeddedRefract(embeddedObj[key]));
     });
   },
 
@@ -871,10 +901,10 @@ var ObjectElement = Collection.extend({
     };
   },
 
-  fromEmbeddedRefract: function(converter, embeddedObj) {
+  fromEmbeddedRefract: function(embeddedObj) {
     var self = this;
     _.forEach(_.keys(embeddedObj), function(key) {
-      self.set(key, converter(embeddedObj[key]));
+      self.set(key, registry.fromEmbeddedRefract(embeddedObj[key]));
     });
   }
 });

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -24,6 +24,44 @@ registry
   .detect(_.isArray, base.ArrayElement, false)
   .detect(_.isObject, base.ObjectElement, false);
 
+function convertFromEmbedded(value) {
+  var element;
+
+  if (_.isArray(value)) {
+    element = new base.ArrayElement();
+
+    _.forEach(value, function(item) {
+      element.push(convertFromEmbedded(item));
+    });
+
+    return element;
+  }
+
+  if (_.isObject(value)) {
+    if (_.has(value, 'refract')) {
+      element = registry.fromRefract(value.refract);
+    } else {
+      element = new base.ObjectElement();
+    }
+
+    // Objects get the properties of the object set as members
+    // All other get the properties set as attributes
+    if (element.primitive() === 'object') {
+      _.forEach(_.keys(_.omit(value, 'refract')), function(key) {
+        element.set(key, convertFromEmbedded(value[key]));
+      });
+    } else {
+      _.forEach(_.keys(_.omit(value, 'refract')), function(key) {
+        element.attributes.set(key, convertFromEmbedded(value[key]));
+      });
+    }
+
+    return element;
+  }
+
+  return registry.toElement(value);
+}
+
 module.exports = _.extend({
     convertToElement: function() {
       return registry.toElement.apply(registry, arguments);
@@ -33,7 +71,8 @@ module.exports = _.extend({
     },
     convertFromCompactRefract: function() {
       return registry.fromCompactRefract.apply(registry, arguments);
-    }
+    },
+    convertFromEmbedded: convertFromEmbedded
   },
   base
 );

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -24,36 +24,6 @@ registry
   .detect(_.isArray, base.ArrayElement, false)
   .detect(_.isObject, base.ObjectElement, false);
 
-function convertFromEmbedded(value) {
-  var element;
-
-  if (_.isArray(value)) {
-    element = new base.ArrayElement();
-
-    _.forEach(value, function(item) {
-      element.push(convertFromEmbedded(item));
-    });
-
-    return element;
-  }
-
-  if (_.isObject(value)) {
-    if (_.has(value, 'refract')) {
-      element = registry.fromRefract(value.refract);
-    } else {
-      element = new base.ObjectElement();
-    }
-
-    // Objects get the properties of the object set as members
-    // All other get the properties set as attributes
-    element.fromEmbeddedRefract(convertFromEmbedded, _.omit(value, 'refract'));
-
-    return element;
-  }
-
-  return registry.toElement(value);
-}
-
 module.exports = _.extend({
     convertToElement: function() {
       return registry.toElement.apply(registry, arguments);
@@ -64,7 +34,9 @@ module.exports = _.extend({
     convertFromCompactRefract: function() {
       return registry.fromCompactRefract.apply(registry, arguments);
     },
-    convertFromEmbedded: convertFromEmbedded
+    convertFromEmbedded: function() {
+      return registry.fromEmbeddedRefract.apply(registry, arguments);
+    }
   },
   base
 );

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -46,15 +46,7 @@ function convertFromEmbedded(value) {
 
     // Objects get the properties of the object set as members
     // All other get the properties set as attributes
-    if (element.primitive() === 'object') {
-      _.forEach(_.keys(_.omit(value, 'refract')), function(key) {
-        element.set(key, convertFromEmbedded(value[key]));
-      });
-    } else {
-      _.forEach(_.keys(_.omit(value, 'refract')), function(key) {
-        element.attributes.set(key, convertFromEmbedded(value[key]));
-      });
-    }
+    element.fromEmbeddedRefract(convertFromEmbedded, _.omit(value, 'refract'));
 
     return element;
   }

--- a/test/embedded-refract-test.js
+++ b/test/embedded-refract-test.js
@@ -190,4 +190,253 @@ describe('Embedded Refract', function() {
       });
     });
   });
+
+  context('when converting to embedded refract', function() {
+    describe('NullElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.NullElement();
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.equal(null);
+        });
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.NullElement(null, {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'null',
+              meta: {},
+              attributes: {
+                foo: 'bar'
+              },
+              content: null
+            }
+          });
+        });
+      });
+    });
+
+    describe('StringElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.StringElement('a');
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.equal('a');
+        });
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.StringElement('a', {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'string',
+              meta: {},
+              attributes: {
+                foo: 'bar'
+              },
+              content: 'a'
+            }
+          });
+        });
+      });
+    });
+
+    describe('NumberElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.NumberElement(4);
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.equal(4);
+        });
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.NumberElement(4, {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'number',
+              meta: {},
+              attributes: {
+                foo: 'bar'
+              },
+              content: 4
+            }
+          });
+        });
+      });
+    });
+
+    describe('BooleanElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.BooleanElement(true);
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.equal(true);
+        });
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.BooleanElement(true, {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'boolean',
+              meta: {},
+              attributes: {
+                foo: 'bar'
+              },
+              content: true
+            }
+          });
+        });
+      });
+    });
+
+    describe('ArrayElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.ArrayElement([1, 2]);
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal([1, 2]);
+        });
+
+        context('when an item has attributes', function() {
+          var element = new minim.ArrayElement([1, 2]);
+          element.first().attributes.set('foo', 'bar');
+
+          it('embeds refract in the item with attributes', function() {
+            expect(element.toEmbeddedRefract()).to.deep.equal([{
+              refract: {
+                element: 'number',
+                meta: {},
+                attributes: { foo: 'bar' },
+                content: 1
+              }
+            }, 2]);
+          });
+        })
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.ArrayElement([1, 2], {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'array',
+              meta: {},
+              attributes: {
+                foo: 'bar'
+              },
+              content: [
+                {
+                  element: 'number',
+                  meta: {},
+                  attributes: {},
+                  content: 1
+                },
+                {
+                  element: 'number',
+                  meta: {},
+                  attributes: {},
+                  content: 2
+                }
+              ]
+            }
+          });
+        });
+      });
+    });
+
+    describe('ObjectElement', function() {
+      context('when no attributes are set', function() {
+        var element = new minim.ObjectElement({ a: 1, b: 2 });
+
+        it('returns its value only', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({ a: 1, b: 2 });
+        });
+
+        context('when an item has attributes', function() {
+          var element = new minim.ObjectElement({ a: 1, b: 2 });
+          element.get('a').attributes.set('foo', 'bar');
+
+          it('embeds refract in the item with attributes', function() {
+            expect(element.toEmbeddedRefract()).to.deep.equal({
+              a: {
+                refract: {
+                  element: 'number',
+                  meta: {},
+                  attributes: { foo: 'bar' },
+                  content: 1
+                }
+              },
+              b: 2
+            });
+          });
+        })
+      });
+
+      context('when attributes have been set', function() {
+        var element = new minim.ObjectElement({ a: 1, b: 2 }, {}, { foo: 'bar' });
+
+        it('returns an embedded refract object', function() {
+          expect(element.toEmbeddedRefract()).to.deep.equal({
+            refract: {
+              element: 'object',
+              meta: {},
+              attributes: { foo: 'bar' },
+              content: [
+                {
+                  element: 'member',
+                  meta: {},
+                  attributes: {},
+                  content: {
+                    key: {
+                      element: 'string',
+                      meta: {},
+                      attributes: {},
+                      content: 'a'
+                    },
+                    value: {
+                      element: 'number',
+                      meta: {},
+                      attributes: {},
+                      content: 1
+                    }
+                  }
+                },
+                {
+                  element: 'member',
+                  meta: {},
+                  attributes: {},
+                  content: {
+                    key: {
+                      element: 'string',
+                      meta: {},
+                      attributes: {},
+                      content: 'b'
+                    },
+                    value: {
+                      element: 'number',
+                      meta: {},
+                      attributes: {},
+                      content: 2
+                    }
+                  }
+                }
+              ]
+            }
+          });
+        });
+      });
+    });
+  });
 });

--- a/test/embedded-refract-test.js
+++ b/test/embedded-refract-test.js
@@ -1,0 +1,193 @@
+var _ = require('lodash');
+var expect = require('./spec-helper').expect;
+var minim = require('../lib/minim');
+
+describe('Embedded Refract', function() {
+  context('when converting from embedded refract', function() {
+    context('when given a normal object', function() {
+      var obj = {
+        foo: 'bar'
+      };
+
+      var element;
+
+      before(function() {
+        element = minim.convertFromEmbedded(obj);
+      });
+
+      it('returns the correct value', function() {
+        expect(element.toValue()).to.deep.equal(obj);
+      });
+    });
+
+    context('when given embedded refract object', function() {
+      // An object { b: 2 } with embedded refract
+      var obj = {
+        refract: {
+          element: 'object',
+          meta: {
+            id: 'test-id'
+          },
+          attributes: {
+            a: 1
+          }
+        },
+        b: 2
+      }
+
+      var refract = {
+        element: 'object',
+        meta: {
+          id: 'test-id'
+        },
+        attributes: {
+          a: 1
+        },
+        content: [
+          {
+            element: 'member',
+            meta: {},
+            attributes: {},
+            content: {
+              key: {
+                element: 'string',
+                meta: {},
+                attributes: {},
+                content: 'b'
+              },
+              value: {
+                element: 'number',
+                meta: {},
+                attributes: {},
+                content: 2
+              }
+            }
+          }
+        ]
+      };
+
+      var element;
+
+      before(function() {
+        element = minim.convertFromEmbedded(obj);
+      });
+
+      it('returns the correct value', function() {
+        expect(element.toRefract()).to.deep.equal(refract);
+      });
+    });
+
+    context('when a property is embedded refract', function() {
+      // Object { a: 1, b: 2, c: 3 } but the value of `b` is embedded refract
+      var obj = {
+        a: 1,
+        b: {
+          refract: {
+            element: 'number',
+            content: 2
+          }
+        },
+        c: 3
+      };
+
+      var expectedObj = {
+        a: 1,
+        b: 2,
+        c: 3
+      };
+
+      var element;
+
+      before(function() {
+        element = minim.convertFromEmbedded(obj);
+      });
+
+      it('returns the correct value', function() {
+        expect(element.toValue()).to.deep.equal(expectedObj);
+      });
+    });
+
+    context('when an array has embedded refract', function() {
+      // An array can have an embedded refract item
+      var obj = {
+        a: [
+          {
+            refract: {
+              element: 'number',
+              content: 1
+            }
+          },
+          2,
+          3
+        ]
+      };
+
+      var expectedObj = {
+        a: [1, 2, 3]
+      };
+
+      var element;
+
+      before(function() {
+        element = minim.convertFromEmbedded(obj);
+      });
+
+      it('returns the correct value', function() {
+        expect(element.toValue()).to.deep.equal(expectedObj);
+      });
+    });
+
+    context('when a non-object embedded refract has attributes', function() {
+      // Properties of non-object Refract element become attributes
+      // With objects, they become part of the content
+      var obj = {
+        a: {
+          refract: {
+            element: 'number',
+            content: 1
+          },
+          foo: 'bar'
+        }
+      };
+
+      var refract = {
+        element: 'object',
+        meta: {},
+        attributes: {},
+        content: [
+          {
+            element: 'member',
+            meta: {},
+            attributes: {},
+            content: {
+              key: {
+                element: 'string',
+                meta: {},
+                attributes: {},
+                content: 'a'
+              },
+              value: {
+                element: 'number',
+                meta: {},
+                attributes: {
+                  foo: 'bar'
+                },
+                content: 1
+              }
+            }
+          }
+        ]
+      };
+
+      var element;
+
+      before(function() {
+        element = minim.convertFromEmbedded(obj);
+      });
+
+      it('returns the correct value', function() {
+        expect(element.toRefract()).to.deep.equal(refract);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Please do not merge**

This just shows how Refract can be embedded inside normal objects. This allows existing structures to be extended simply by adding a `refract` property.
