### PR TITLE
Update functional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,15 @@ var arrayElement = new minim.ArrayElement(['a', 'b', 'c']);
 var value = arrayElement.getValue(0) // get(0) returns 'a'
 ```
 
+##### getIndex
+
+The `getIndex` method returns the item of the array at a given index.
+
+```javascript
+var arrayElement = new minim.ArrayElement(['a', 'b', 'c']);
+var value = arrayElement.getIndex(0) // returns the item for 'a'
+```
+
 ##### set
 
 The `set` method sets the value of the `ArrayElement` instance.
@@ -267,6 +276,26 @@ var arrayElement = new minim.ArrayElement(['a', 'b', 'c']);
 var newArray = arrayElement.filter(function(item) {
   return item.get() === 'a'
 }); // newArray.toValue() is now ['a']
+```
+
+##### reduce
+
+The `reduce` method may be used to reduce over a Minim array or object. The method takes a function and an optional beginning value.
+
+```javascript
+var numbers = new minim.ArrayElement([1, 2, 3, 4]);
+var total = numbers.reduce(function(result, item) {
+  return result.toValue() + item.toValue();
+}); // total.toValue() === 10
+```
+
+The `reduce` method also takes an initial value, which can either be a value or Minim element.
+
+```javascript
+var numbers = new minim.ArrayElement([1, 2, 3, 4]);
+var total = numbers.reduce(function(result, item) {
+  return result.toValue() + item.toValue();
+}, 10); // total.toValue() === 20
 ```
 
 ##### forEach

--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ var stringElement = minim.convertToElement("foobar");
 stringElement.equals('abcd'); // returns false
 ```
 
+#### clone
+
+Creates a clone of the given instance.
+
+```javascript
+var stringElement = minim.convertToElement("foobar");
+var stringElementClone = stringElement.clone();
+```
+
 ### Minim Elements
 
 Minim supports the following primitive elements

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -125,19 +125,23 @@ module.exports = function(BaseElement, registry) {
       var recursive = !!options.recursive;
       var results = options.results === undefined ? [] : options.results;
 
-      this.content.forEach(function(el) {
+      // The forEach method for Object Elements returns value, key, and member.
+      // This passes those along to the condition function below.
+      this.forEach(function(item, keyOrIndex, member) {
         // We use duck-typing here to support any registered class that
         // may contain other elements.
-        if (recursive && (el.findElements !== undefined)) {
-          el.findElements(condition, {
+        if (recursive && (item.findElements !== undefined)) {
+          item.findElements(condition, {
             results: results,
             recursive: recursive
           });
         }
-        if (condition(el)) {
-          results.push(el);
+
+        if (condition(item, keyOrIndex, member)) {
+          results.push(item);
         }
       });
+
       return results;
     },
 

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -149,7 +149,9 @@ module.exports = function(BaseElement, registry) {
     },
 
     forEach: function(cb) {
-      this.content.forEach(cb);
+      this.content.forEach(function(item, index) {
+        cb(item, registry.toElement(index));
+      });
     },
 
     push: function(value) {

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -92,6 +92,10 @@ module.exports = function(BaseElement, registry) {
       return undefined;
     },
 
+    getIndex: function(index) {
+      return this.content[index];
+    },
+
     set: function(index, value) {
       this.content[index] = registry.toElement(value);
       return this;
@@ -105,6 +109,43 @@ module.exports = function(BaseElement, registry) {
       var newArray = new ArrayElement();
       newArray.content = this.content.filter(condition);
       return newArray;
+    },
+
+    /*
+     * This is a reduce function specifically for Minim arrays and objects. It
+     * allows for returning normal values or Minim instances, so it converts any
+     * primitives on each step.
+     */
+    reduce: function(fn, givenMemo) {
+      var startIndex;
+      var memo;
+
+      // Allows for defining a starting value of the reduce
+      if (!_.isUndefined(givenMemo)) {
+        startIndex = 0;
+        memo = registry.toElement(givenMemo);
+      } else {
+        startIndex = 1;
+        // Object Element content items are member elements. Because of this,
+        // the memo should start out as the member value rather than the
+        // actual member itself.
+        memo = this.primitive() === 'object' ? this.first().value : this.first();
+      }
+
+      // Sending each function call to the registry allows for passing Minim
+      // instances through the function return. This means you can return
+      // primitive values or return Minim instances and reduce will still work.
+      for (var i = startIndex; i < this.length; i++) {
+        var item = this.content[i];
+
+        if (this.primitive() === 'object') {
+          memo = registry.toElement(fn(memo, item.value, item.key, item));
+        } else {
+          memo = registry.toElement(fn(memo, item));
+        }
+      }
+
+      return memo;
     },
 
     forEach: function(cb) {
@@ -188,21 +229,21 @@ module.exports = function(BaseElement, registry) {
      * Return the first item in the collection
      */
     first: function() {
-      return this.get(0);
+      return this.getIndex(0);
     },
 
     /*
      * Return the second item in the collection
      */
     second: function() {
-      return this.get(1);
+      return this.getIndex(1);
     },
 
     /*
      * Return the last item in the collection
      */
     last: function() {
-      return this.get(this.length - 1);
+      return this.getIndex(this.length - 1);
     },
 
     /*

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -25,6 +25,13 @@ module.exports = function(registry) {
       return;
     },
 
+    /*
+     * Creates a deep clone of the instance
+     */
+    clone: function() {
+      return registry.fromRefract(this.toRefract());
+    },
+
     toValue: function() {
       return this.content;
     },

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -17,7 +17,7 @@ module.exports = function(registry) {
         this.attributes.set(attributes);
       }
 
-      this.content = content || null;
+      this.content = content !== undefined ? content : null;
       this._attributeElementKeys = [];
     },
 

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -225,6 +225,15 @@ describe('ArrayElement', function() {
     //     expect(items).to.have.length(4);
     //   });
     // });
+
+    describe('#clone', function() {
+      it('creates a deep clone of the element', function() {
+        var clone = arrayElement.clone();
+        expect(clone).to.be.instanceOf(minim.ArrayElement);
+        expect(clone).to.not.equal(arrayElement);
+        expect(clone.toRefract()).to.deep.equal(arrayElement.toRefract());
+      });
+    });
   });
 
   describe('searching', function() {

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -123,6 +123,14 @@ describe('ArrayElement', function() {
       });
     });
 
+    describe('#getIndex', function() {
+      var numbers = new minim.ArrayElement([1, 2, 3, 4]);
+
+      it('returns the correct item', function() {
+        expect(numbers.getIndex(1).toValue()).to.equal(2);
+      });
+    });
+
     describe('#set', function() {
       it('sets the value of the array', function() {
         arrayElement.set(0, 'hello world');
@@ -146,6 +154,28 @@ describe('ArrayElement', function() {
           return (ref = item.toValue()) === 'a' || ref === 1;
         });
         expect(newArray.toValue()).to.deep.equal(['a', 1]);
+      });
+    });
+
+    describe('#reduce', function() {
+      var numbers = new minim.ArrayElement([1, 2, 3, 4]);
+
+      context('when no beginning value is given', function() {
+        it('correctly reduces the array', function() {
+          var total = numbers.reduce(function(result, item) {
+            return result.toValue() + item.toValue();
+          });
+          expect(total.toValue()).to.equal(10);
+        });
+      });
+
+      context('when a beginning value is given', function() {
+        it('correctly reduces the array', function() {
+          var total = numbers.reduce(function(result, item) {
+            return result.toValue() + item.toValue();
+          }, 20);
+          expect(total.toValue()).to.equal(30);
+        });
       });
     });
 

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -181,12 +181,16 @@ describe('ArrayElement', function() {
 
     describe('#forEach', function() {
       it('iterates over each item', function() {
-        var results;
-        results = [];
-        arrayElement.forEach(function(item) {
-          return results.push(item);
+        var indexes = [];
+        var results = [];
+
+        arrayElement.forEach(function(item, index) {
+          indexes.push(index.toValue());
+          results.push(item);
         });
+
         expect(results.length).to.equal(4);
+        expect(indexes).to.deep.equal([0, 1, 2, 3]);
       });
     });
 

--- a/test/primitives/boolean-element-test.js
+++ b/test/primitives/boolean-element-test.js
@@ -60,4 +60,13 @@ describe('BooleanElement', function() {
       expect(booleanElement.toValue()).to.equal(false);
     });
   });
+
+  describe('#clone', function() {
+    it('creates a deep clone of the element', function() {
+      var clone = booleanElement.clone();
+      expect(clone).to.be.instanceOf(minim.BooleanElement);
+      expect(clone).to.not.equal(booleanElement);
+      expect(clone.toRefract()).to.deep.equal(booleanElement.toRefract());
+    });
+  });
 });

--- a/test/primitives/null-element-test.js
+++ b/test/primitives/null-element-test.js
@@ -58,4 +58,13 @@ describe('NullElement', function() {
       expect(nullElement.set('foobar')).to.be.an.instanceof(Error);
     });
   });
+
+  describe('#clone', function() {
+    it('creates a deep clone of the element', function() {
+      var clone = nullElement.clone();
+      expect(clone).to.be.instanceOf(minim.NullElement);
+      expect(clone).to.not.equal(nullElement);
+      expect(clone.toRefract()).to.deep.equal(nullElement.toRefract());
+    });
+  });
 });

--- a/test/primitives/number-element-test.js
+++ b/test/primitives/number-element-test.js
@@ -60,4 +60,13 @@ describe('NumberElement', function() {
       expect(numberElement.toValue()).to.equal(10);
     });
   });
+
+  describe('#clone', function() {
+    it('creates a deep clone of the element', function() {
+      var clone = numberElement.clone();
+      expect(clone).to.be.instanceOf(minim.NumberElement);
+      expect(clone).to.not.equal(numberElement);
+      expect(clone.toRefract()).to.deep.equal(numberElement.toRefract());
+    });
+  });
 });

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -382,6 +382,15 @@ describe('ObjectElement', function() {
     });
   });
 
+  describe('#clone', function() {
+    it('creates a deep clone of the element', function() {
+      var clone = objectElement.clone();
+      expect(clone).to.be.instanceOf(minim.ObjectElement);
+      expect(clone).to.not.equal(objectElement);
+      expect(clone.toRefract()).to.deep.equal(objectElement.toRefract());
+    });
+  });
+
   // describe('#[Symbol.iterator]', function() {
   //   it('can be used in a for ... of loop', function() {
   //     var items = [];

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -332,6 +332,22 @@ describe('ObjectElement', function() {
     });
   });
 
+  describe('#find', function() {
+    it('allows for searching based on the keys', function() {
+      var search = objectElement.find(function(value, key) {
+        return key.toValue() === 'z';
+      });
+      expect(search.toValue()).to.deep.equal([1]);
+    });
+
+    it('allows for searching based on the member', function() {
+      var search = objectElement.find(function(value, key, member) {
+        return member.key.toValue() === 'z';
+      });
+      expect(search.toValue()).to.deep.equal([1]);
+    });
+  });
+
   // describe('#[Symbol.iterator]', function() {
   //   it('can be used in a for ... of loop', function() {
   //     var items = [];

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -306,6 +306,40 @@ describe('ObjectElement', function() {
     });
   });
 
+  describe('#reduce', function() {
+    var numbers = new minim.ObjectElement({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    });
+
+    it('allows for reducing on keys', function() {
+      var letters = numbers.reduce(function(result, item, key) {
+        return result.push(key);
+      }, []);
+      expect(letters.toValue()).to.deep.equal(['a', 'b', 'c', 'd']);
+    });
+
+    context('when no beginning value is given', function() {
+      it('correctly reduces the object', function() {
+        var total = numbers.reduce(function(result, item) {
+          return result.toValue() + item.toValue();
+        });
+        expect(total.toValue()).to.equal(10);
+      });
+    });
+
+    context('when a beginning value is given', function() {
+      it('correctly reduces the object', function() {
+        var total = numbers.reduce(function(result, item) {
+          return result.toValue() + item.toValue();
+        }, 20);
+        expect(total.toValue()).to.equal(30);
+      });
+    });
+  });
+
   describe('#forEach', function() {
     it('provides the keys', function() {
       var keys = [];

--- a/test/primitives/string-element-test.js
+++ b/test/primitives/string-element-test.js
@@ -60,4 +60,13 @@ describe('StringElement', function() {
       expect(stringElement.toValue()).to.equal('hello world');
     });
   });
+
+  describe('#clone', function() {
+    it('creates a deep clone of the element', function() {
+      var clone = stringElement.clone();
+      expect(clone).to.be.instanceOf(minim.StringElement);
+      expect(clone).to.not.equal(stringElement);
+      expect(clone.toRefract()).to.deep.equal(stringElement.toRefract());
+    });
+  });
 });


### PR DESCRIPTION
This PR does the following:
- Updates how the `find` method works.
- Adds reduce function
- Adds clone function
- Updates `forEach` for Array Element to return indexes
- Updates `map` for Array and Object Elements to return Array Element

The last commit is a big change. It converts `map` to be a special kind of map, where instead of getting back a normal JavaScript array, you get back an Array Element. This follows with the idea that all of these instance methods are Minim-specific.
