### PR TITLE
Add getIn method for array elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ var arrayElement = new minim.ArrayElement(['a', 'b', 'c']);
 var value = arrayElement.getValue(0) // get(0) returns 'a'
 ```
 
+##### getIn
+
+The `getIn` method returns the value of the item at the given path.
+
+```javascript
+var arrayElement = new minim.ArrayElement([{
+  a: [1, 2, 3]
+}]);
+var value = arrayElement.getIn([0, 'a', 1]) // returns the element for 2
+```
+
+
 ##### set
 
 The `set` method sets the value of the `ArrayElement` instance.

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -92,6 +92,15 @@ module.exports = function(BaseElement, registry) {
       return undefined;
     },
 
+    /*
+     * It reduces through a given array and calls get on each item.
+     */
+    getIn: function(paths) {
+      return _.reduce(paths, function(result, path) {
+        return result.get(path);
+      }, this);
+    },
+
     set: function(index, value) {
       this.content[index] = registry.toElement(value);
       return this;

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -123,6 +123,16 @@ describe('ArrayElement', function() {
       });
     });
 
+    describe('#getIn', function() {
+      var arr = new minim.ArrayElement([
+        {
+          a: [1, 2, 3]
+        }
+      ]);
+
+      expect(arr.getIn([0, 'a', 1]).toValue()).to.equal(2);
+    });
+
     describe('#set', function() {
       it('sets the value of the array', function() {
         arrayElement.set(0, 'hello world');


### PR DESCRIPTION
Given a tree like this:

``` js
{
  a: {
    b: {
      c: [1, 2, 3]
    }
  }
}
```

You can currently do this:

``` js
obj
  .get('a')
  .get('b')
  .get('c')
  .get(1)
```

This would give you the value of 2.

With `getIn`, you can now do.

``` js
obj.getIn(['a', 'b', 'c', 1]);
```
