### PR TITLE
Properly handle falsey element content values.

### DIFF
--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -17,7 +17,7 @@ module.exports = function(registry) {
         this.attributes.set(attributes);
       }
 
-      this.content = content || null;
+      this.content = content !== undefined ? content : null;
       this._attributeElementKeys = [];
     },
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -23,6 +23,25 @@ describe('BaseElement', function() {
     });
   });
 
+  describe('when initializing with value', function() {
+    var el;
+
+    it('should properly serialize falsey string', function() {
+      el = new minim.BaseElement('');
+      expect(el.toValue()).to.equal('');
+    });
+
+    it('should properly serialize falsey number', function() {
+      el = new minim.BaseElement(0);
+      expect(el.toValue()).to.equal(0);
+    });
+
+    it('should properly serialize falsey boolean', function() {
+      el = new minim.BaseElement(false);
+      expect(el.toValue()).to.equal(false);
+    });
+  });
+
   describe('#attributes', function() {
     var element;
 


### PR DESCRIPTION
This fixes the following issue:

``` js
let el = new minim.StringElement('');
expect(el.toValue()).to.equal('');
// => Fails with `null` !== `''`
```

The same thing happens for numbers and boolean elements.

---

On a related note, we may want to consider using `undefined` for the content instead of `null` to denote 'nothing is set' on the element. That makes this code even simpler by just using `this.content = content`. I forget if there is a reason to use `null`... thoughts?

cc @smizell 
