### PR TITLE
Add convenience to get values from ObjectElement.

### DIFF
--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -56,6 +56,14 @@ module.exports = function(BaseElement, ArrayElement, MemberElement) {
     },
 
     /*
+     * Returns the `toValue` result of the value if it exists.
+    */
+    getToValue: function(name) {
+      var value = this.get(name);
+      return value && value.toValue();
+    },
+
+    /*
      * Set allows either a key/value pair to be given or an object
      * If an object is given, each key is set to its respective value
      */


### PR DESCRIPTION
This adds a small convenience function to simplify the following code, which
winds up being really common in tooling that makes use of Minim:

``` js
const element = element.attributes.get('href');
const href = element && element.toValue();
```

Now you can do:

``` js
const href = element.attributes.getToValue('href');
```

This also makes things _significantly_ easier when using `meta`/`attributes`
within templates (e.g. Jade, EJS, Swig), particularly in cases where the
rendered template JS causes the `this` context to be lost when calling
`toValue()` which results in undefined `this` errors.

cc @smizell 
