### PR TITLE
Return value result from simple types for convenience attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Each Minim element provides the following attributes:
 - attributes (object) - The element's attributes
 - content - The element's content, e.g. a list of other elements.
 
+Additionally, convenience attributes are exposed on the element:
+
+- id (string) - Shortcut for `.meta.get('id').toValue()`.
+- name (string) - Shortcut for `.meta.get('name').toValue()`.
+- class (ArrayElement) - Shortcut for `.meta.get('class')`.
+- title (string) - Shortcut for `.meta.get('title').toValue()`.
+- description (string) - Shortcut for `.meta.get('description').toValue()`.
+
+Note that simple types like `string` are exposed through their `.toValue()` result, while more complex types like the array for the `class` attribute are exposed as `ArrayElement` or `ObjectElement` instances.
+
 ### Element Methods
 
 Each Minim element provides the following the methods.

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -176,7 +176,7 @@ module.exports = function(BaseElement, registry) {
      */
     getById: function(id) {
       return this.find(function(item) {
-        return item.id.toValue() === id;
+        return item.id === id;
       }).first();
     },
 

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -172,7 +172,7 @@ module.exports = function(registry) {
 
     id: {
       get: function() {
-        return this.getMetaProperty('id', '');
+        return this.getMetaProperty('id', '').toValue();
       },
       set: function(element) {
         this.setMetaProperty('id', element);
@@ -192,7 +192,7 @@ module.exports = function(registry) {
     // Requires updating subclass test
     name: {
       get: function() {
-        return this.getMetaProperty('name', '');
+        return this.getMetaProperty('name', '').toValue();
       },
       set: function(element) {
         this.setMetaProperty('name', element);
@@ -201,7 +201,7 @@ module.exports = function(registry) {
 
     title: {
       get: function() {
-        return this.getMetaProperty('title', '');
+        return this.getMetaProperty('title', '').toValue();
       },
       set: function(element) {
         this.setMetaProperty('title', element);
@@ -210,7 +210,7 @@ module.exports = function(registry) {
 
     description: {
       get: function() {
-        return this.getMetaProperty('description', '');
+        return this.getMetaProperty('description', '').toValue();
       },
       set: function(element) {
         this.setMetaProperty('description', element);

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -84,11 +84,11 @@ describe('BaseElement', function() {
     });
 
     it('returns true when they are equal', function() {
-      expect(el.id.equals('foobar')).to.be.true;
+      expect(el.meta.get('id').equals('foobar')).to.be.true;
     });
 
     it('returns false when they are not equal', function() {
-      expect(el.id.equals('not-equal')).to.be.false;
+      expect(el.meta.get('id').equals('not-equal')).to.be.false;
     });
 
     it('does a deep equality check', function() {
@@ -110,7 +110,11 @@ describe('BaseElement', function() {
 
       _.forEach(_.keys(meta), function(key) {
         it('provides a convenience method for ' + key, function() {
-          expect(el[key].toValue()).to.deep.equal(meta[key]);
+          if (key === 'class') {
+            expect(el[key].toValue()).to.deep.equal(meta[key]);
+          } else {
+            expect(el[key]).to.deep.equal(meta[key]);
+          }
         });
       });
     });
@@ -122,7 +126,11 @@ describe('BaseElement', function() {
         el[key] = meta[key];
 
         it('works for getters and setters for ' + key, function() {
-          expect(el[key].toValue()).to.deep.equal(meta[key]);
+          if (key === 'class') {
+            expect(el[key].toValue()).to.deep.equal(meta[key]);
+          } else {
+            expect(el[key]).to.deep.equal(meta[key]);
+          }
         });
 
         it('stores the correct data in meta for ' + key, function() {


### PR DESCRIPTION
This changes the return value of the convenience attributes (e.g. `id`,
`title`, etc) to return the result of `.toValue()`. It **only** does so for
simple types (string, number, boolean, null) and leaves more complex types
alone.

``` js
console.log(element.title); // => 'I am a title'
console.log(element.description); // => ''

// Since `class` is an array, it is still an element instance
if (element.class.contains('foo')) {
  console.log('Contains foo.');
}
```

cc @smizell - any other thoughts on whether `.class` should be an array vs. ArrayElement instance? It seems super useful to keep it as an element instance, but makes accessing the strings within a bit harder.
