### PR TITLE
Implement iterator protocol for arrays & objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,7 @@ This is an element for representing arrays.
 
 ##### Iteration
 
-**NOTE**: Not usable at this point
-
-The array element is iterable.
+The array element is iterable if the environment supports the [iteration protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#iterable). You can then use the element in `for ... of` loops, use the spread operator, `yield*`, and destructuring assignment.
 
 ```js
 const arrayElement = new minim.ArrayElement(['a', 'b', 'c']);

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -269,5 +269,11 @@ module.exports = function(BaseElement, registry) {
     }
   });
 
+  if (typeof Symbol !== 'undefined') {
+    ArrayElement.prototype[Symbol.iterator] = function () {
+      return this.content[Symbol.iterator]();
+    };
+  }
+
   return ArrayElement;
 };

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -231,17 +231,6 @@ describe('ArrayElement', function() {
       });
     });
 
-    // describe('#[Symbol.iterator]', function() {
-    //   it('can be used in a for ... of loop', function() {
-    //     var items = [];
-    //     for (let item of ArrayElement) {
-    //       items.push(item);
-    //     }
-    //
-    //     expect(items).to.have.length(4);
-    //   });
-    // });
-
     describe('#clone', function() {
       it('creates a deep clone of the element', function() {
         var clone = arrayElement.clone();
@@ -250,6 +239,30 @@ describe('ArrayElement', function() {
         expect(clone.toRefract()).to.deep.equal(arrayElement.toRefract());
       });
     });
+
+    if (typeof Symbol !== 'undefined') {
+      describe('#[Symbol.iterator]', function() {
+        it('can be used in a for ... of loop', function() {
+          // We know the runtime supports Symbol but don't know if it supports
+          // the actual `for ... of` loop syntax. Here we simulate it by
+          // directly manipulating the iterator the same way that `for ... of`
+          // does.
+          var items = [];
+          var iterator = arrayElement[Symbol.iterator]();
+          var result;
+
+          do {
+            result = iterator.next();
+
+            if (!result.done) {
+              items.push(result.value);
+            }
+          } while (!result.done);
+
+          expect(items).to.have.length(4);
+        });
+      });
+    }
   });
 
   describe('searching', function() {


### PR DESCRIPTION
This re-enables the iterator protocol when available in the runtime to allow
iterating over elements:

``` js
const numbers = new minim.ArrayElement([1, 2, 3, 4]);
let sum = 0;
for (let n of numbers) {
  sum += n.toValue();
}

// Also works for objects.
const items = new minim.ObjectElement({a: 1, b: 2});
for (let item of items) {
  console.log(`${item.key.toValue()}: ${item.value.toValue()}`);
}

// Not just for ... of loops:
const simpleArray = [...numbers];
const [first, second, ...rest] = numbers;
```

cc @smizell 
