### PR TITLE
Fix registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Change interface to allow for custom registries.
 - Rename the `class` metadata property to `classes`. The convenience property
   is also now called `classes`, e.g. `element.classes.contains('abc')`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ var el = {
 ### Converting Javascript Values into Elements
 
 ```javascript
-var minim = require('minim');
+var minim = require('minim').init();
 var arrayElement = minim.convertToElement([1, 2, 3]);
 var refract = arrayElement.toRefract();
 ```
@@ -540,7 +540,7 @@ const values = objectElement.map((value, key, member) => {
 Minim allows you to register custom elements. For example, if the element name you wish to handle is called `category` and it should be handled like an array:
 
 ```javascript
-var minim = require('minim');
+var minim = require('minim').init();
 
 // Register your custom element
 minim.registry.register('category', minim.ArrayElement);
@@ -554,6 +554,14 @@ console.log(elements.get(0).content); // hello, world
 
 // Unregister your custom element
 minim.registry.unregister('category');
+```
+
+You may also pass in a registries that may have been initialized elsewhere.
+
+```javascript
+var ElementRegistry = require('minim').ElementRegistry;
+var registry = new ElementRegistry();
+var minim = require('minim').init(registry);
 ```
 
 ### Chaining

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,113 +1,10 @@
 'use strict';
 
+var _ = require('lodash');
+
 var uptown = require('uptown');
 var createClass = uptown.createClass;
-
-var BaseElement;
-
-/*
- * A refract element implementation with an extensible element registry.
- *
- * The element registry allows you to register your own classes to be instantiated
- * when a particular refract element is encountered, and allows you to specify
- * which elements get instantiated for existing Javascript objects.
- */
-
-var ElementRegistry = createClass({
-  constructor: function() {
-    this.elementMap = {};
-    this.elementDetection = [];
-  },
-
-  /*
-   * Register a new element class for an element.
-   */
-  register: function(name, ElementClass) {
-    this.elementMap[name] = ElementClass;
-    return this;
-  },
-
-  /*
-   * Unregister a previously registered class for an element.
-   */
-  unregister: function(name) {
-    delete this.elementMap[name];
-    return this;
-  },
-
-  /*
-   * Add a new detection function to determine which element
-   * class to use when converting existing js instances into
-   * refract element.
-   */
-  detect: function(test, ElementClass, givenPrepend) {
-    var prepend = givenPrepend === undefined ? true : givenPrepend;
-
-    if (prepend) {
-      this.elementDetection.unshift([test, ElementClass]);
-    } else {
-      this.elementDetection.push([test, ElementClass]);
-    }
-
-    return this;
-  },
-
-  /*
-   * Convert an existing Javascript object into refract element instances, which
-   * can be further processed or serialized into refract or compact refract.
-   * If the item passed in is already refracted, then it is returned
-   * unmodified.
-   */
-  toElement: function(value) {
-    if (value instanceof BaseElement) { return value; }
-
-    var element;
-
-    for(var i = 0; i < this.elementDetection.length; i++) {
-      var test = this.elementDetection[i][0];
-      var ElementClass = this.elementDetection[i][1];
-
-      if (test(value)) {
-        element = new ElementClass(value);
-        break;
-      }
-    }
-
-    return element;
-  },
-
-  /*
-   * Get an element class given an element name.
-   */
-  getElementClass: function(element) {
-    var ElementClass = this.elementMap[element];
-
-    if (ElementClass === undefined) {
-      // Fall back to the base element. We may not know what
-      // to do with the `content`, but downstream software
-      // may know.
-      return BaseElement;
-    }
-
-    return ElementClass;
-  },
-
-  /*
-   * Convert a long-form refract document into refract element instances.
-   */
-   fromRefract: function(doc) {
-    var ElementClass = this.getElementClass(doc.element);
-    return new ElementClass().fromRefract(doc);
-  },
-
-  /*
-   * Convert a compact refract tuple into refract element instances.
-   */
-  fromCompactRefract: function(tuple) {
-    var ElementClass = this.getElementClass(tuple[0]);
-    return new ElementClass().fromCompactRefract(tuple);
-  }
-});
+var ElementRegistry = require('./registry').ElementRegistry;
 
 // Initiate a default Minim registry
 var registry = new ElementRegistry();
@@ -115,7 +12,10 @@ var registry = new ElementRegistry();
 // Use dependency injection so we can split up into multiple files yet resolve
 // any circuluar dependencies. BaseElement is also defined above in order to
 // satisfy any linting issues.
-BaseElement = require('./primitives/base-element')(registry);
+var BaseElement = require('./primitives/base-element')(registry);
+
+registry.BaseElement = BaseElement;
+
 var NullElement = require('./primitives/null-element')(BaseElement);
 var StringElement = require('./primitives/string-element')(BaseElement);
 var NumberElement = require('./primitives/number-element')(BaseElement);
@@ -123,6 +23,26 @@ var BooleanElement = require('./primitives/boolean-element')(BaseElement);
 var ArrayElement = require('./primitives/array-element')(BaseElement, registry);
 var MemberElement = require('./primitives/member-element')(BaseElement, registry);
 var ObjectElement = require('./primitives/object-element')(BaseElement, ArrayElement, MemberElement);
+
+// Set up classes for default elements
+registry
+  .register('null', NullElement)
+  .register('string', StringElement)
+  .register('number', NumberElement)
+  .register('boolean', BooleanElement)
+  .register('array', ArrayElement)
+  .register('object', ObjectElement)
+  .register('member', MemberElement);
+
+// Add instance detection functions to convert existing objects into
+// the corresponding refract elements.
+registry
+  .detect(_.isNull, NullElement, false)
+  .detect(_.isString, StringElement, false)
+  .detect(_.isNumber, NumberElement, false)
+  .detect(_.isBoolean, BooleanElement, false)
+  .detect(_.isArray, ArrayElement, false)
+  .detect(_.isObject, ObjectElement, false);
 
 module.exports = {
   BaseElement: BaseElement,

--- a/lib/base.js
+++ b/lib/base.js
@@ -2,8 +2,6 @@
 
 var _ = require('lodash');
 
-var uptown = require('uptown');
-var createClass = uptown.createClass;
 var ElementRegistry = require('./registry').ElementRegistry;
 
 exports.init = function(registry) {
@@ -68,4 +66,4 @@ exports.init = function(registry) {
       return registry.fromCompactRefract.apply(registry, arguments);
     }
   };
-}
+};

--- a/lib/base.js
+++ b/lib/base.js
@@ -6,53 +6,66 @@ var uptown = require('uptown');
 var createClass = uptown.createClass;
 var ElementRegistry = require('./registry').ElementRegistry;
 
-// Initiate a default Minim registry
-var registry = new ElementRegistry();
+exports.init = function(registry) {
+  // Allows for passing in a custom registry
+  if (!registry) {
+    registry = new ElementRegistry();
+  }
 
-// Use dependency injection so we can split up into multiple files yet resolve
-// any circuluar dependencies. BaseElement is also defined above in order to
-// satisfy any linting issues.
-var BaseElement = require('./primitives/base-element')(registry);
+  // Use dependency injection so we can split up into multiple files yet resolve
+  // any circuluar dependencies. BaseElement is also defined above in order to
+  // satisfy any linting issues.
+  var BaseElement = require('./primitives/base-element')(registry);
 
-registry.BaseElement = BaseElement;
+  // The registry needs a base element to determine the base type of an element.
+  registry.BaseElement = BaseElement;
 
-var NullElement = require('./primitives/null-element')(BaseElement);
-var StringElement = require('./primitives/string-element')(BaseElement);
-var NumberElement = require('./primitives/number-element')(BaseElement);
-var BooleanElement = require('./primitives/boolean-element')(BaseElement);
-var ArrayElement = require('./primitives/array-element')(BaseElement, registry);
-var MemberElement = require('./primitives/member-element')(BaseElement, registry);
-var ObjectElement = require('./primitives/object-element')(BaseElement, ArrayElement, MemberElement);
+  var NullElement = require('./primitives/null-element')(BaseElement);
+  var StringElement = require('./primitives/string-element')(BaseElement);
+  var NumberElement = require('./primitives/number-element')(BaseElement);
+  var BooleanElement = require('./primitives/boolean-element')(BaseElement);
+  var ArrayElement = require('./primitives/array-element')(BaseElement, registry);
+  var MemberElement = require('./primitives/member-element')(BaseElement, registry);
+  var ObjectElement = require('./primitives/object-element')(BaseElement, ArrayElement, MemberElement);
 
-// Set up classes for default elements
-registry
-  .register('null', NullElement)
-  .register('string', StringElement)
-  .register('number', NumberElement)
-  .register('boolean', BooleanElement)
-  .register('array', ArrayElement)
-  .register('object', ObjectElement)
-  .register('member', MemberElement);
+  // Set up classes for default elements
+  registry
+    .register('null', NullElement)
+    .register('string', StringElement)
+    .register('number', NumberElement)
+    .register('boolean', BooleanElement)
+    .register('array', ArrayElement)
+    .register('object', ObjectElement)
+    .register('member', MemberElement);
 
-// Add instance detection functions to convert existing objects into
-// the corresponding refract elements.
-registry
-  .detect(_.isNull, NullElement, false)
-  .detect(_.isString, StringElement, false)
-  .detect(_.isNumber, NumberElement, false)
-  .detect(_.isBoolean, BooleanElement, false)
-  .detect(_.isArray, ArrayElement, false)
-  .detect(_.isObject, ObjectElement, false);
+  // Add instance detection functions to convert existing objects into
+  // the corresponding refract elements.
+  registry
+    .detect(_.isNull, NullElement, false)
+    .detect(_.isString, StringElement, false)
+    .detect(_.isNumber, NumberElement, false)
+    .detect(_.isBoolean, BooleanElement, false)
+    .detect(_.isArray, ArrayElement, false)
+    .detect(_.isObject, ObjectElement, false);
 
-module.exports = {
-  BaseElement: BaseElement,
-  NullElement: NullElement,
-  StringElement: StringElement,
-  NumberElement: NumberElement,
-  BooleanElement: BooleanElement,
-  ArrayElement: ArrayElement,
-  MemberElement: MemberElement,
-  ObjectElement: ObjectElement,
-  ElementRegistry: ElementRegistry,
-  registry: registry
-};
+  return {
+    BaseElement: BaseElement,
+    NullElement: NullElement,
+    StringElement: StringElement,
+    NumberElement: NumberElement,
+    BooleanElement: BooleanElement,
+    ArrayElement: ArrayElement,
+    MemberElement: MemberElement,
+    ObjectElement: ObjectElement,
+    registry: registry,
+    convertToElement: function() {
+      return registry.toElement.apply(registry, arguments);
+    },
+    convertFromRefract: function() {
+      return registry.fromRefract.apply(registry, arguments);
+    },
+    convertFromCompactRefract: function() {
+      return registry.fromCompactRefract.apply(registry, arguments);
+    }
+  };
+}

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var _ = require('lodash');
-var base = require('./base').init();
-var registry = base.registry;
-
-module.exports = base;
+// Provide a common interface to Minim
+// This allows for the base initialization code to be used and custom registries
+// to be created rather than have one global registry.
+module.exports = require('./base').init();

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -1,6 +1,8 @@
 'use strict';
 
-// Provide a common interface to Minim
-// This allows for the base initialization code to be used and custom registries
-// to be created rather than have one global registry.
-module.exports = require('./base').init();
+var base = require('./base');
+
+module.exports = {
+  init: base.init,
+  ElementRegistry: require('../lib/registry').ElementRegistry
+};

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -1,19 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var base = require('./base');
+var base = require('./base').init();
 var registry = base.registry;
 
-module.exports = _.extend({
-    convertToElement: function() {
-      return registry.toElement.apply(registry, arguments);
-    },
-    convertFromRefract: function() {
-      return registry.fromRefract.apply(registry, arguments);
-    },
-    convertFromCompactRefract: function() {
-      return registry.fromCompactRefract.apply(registry, arguments);
-    }
-  },
-  base
-);
+module.exports = base;

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -4,26 +4,6 @@ var _ = require('lodash');
 var base = require('./base');
 var registry = base.registry;
 
-// Set up classes for default elements
-registry
-  .register('null', base.NullElement)
-  .register('string', base.StringElement)
-  .register('number', base.NumberElement)
-  .register('boolean', base.BooleanElement)
-  .register('array', base.ArrayElement)
-  .register('object', base.ObjectElement)
-  .register('member', base.MemberElement);
-
-// Add instance detection functions to convert existing objects into
-// the corresponding refract elements.
-registry
-  .detect(_.isNull, base.NullElement, false)
-  .detect(_.isString, base.StringElement, false)
-  .detect(_.isNumber, base.NumberElement, false)
-  .detect(_.isBoolean, base.BooleanElement, false)
-  .detect(_.isArray, base.ArrayElement, false)
-  .detect(_.isObject, base.ObjectElement, false);
-
 module.exports = _.extend({
     convertToElement: function() {
       return registry.toElement.apply(registry, arguments);

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,0 +1,110 @@
+var uptown = require('uptown');
+var createClass = uptown.createClass;
+
+/*
+ * A refract element implementation with an extensible element registry.
+ *
+ * The element registry allows you to register your own classes to be instantiated
+ * when a particular refract element is encountered, and allows you to specify
+ * which elements get instantiated for existing Javascript objects.
+ */
+
+var ElementRegistry = createClass({
+  constructor: function() {
+    this.elementMap = {};
+    this.elementDetection = [];
+  },
+
+  /*
+   * Register a new element class for an element.
+   */
+  register: function(name, ElementClass) {
+    this.elementMap[name] = ElementClass;
+    return this;
+  },
+
+  /*
+   * Unregister a previously registered class for an element.
+   */
+  unregister: function(name) {
+    delete this.elementMap[name];
+    return this;
+  },
+
+  /*
+   * Add a new detection function to determine which element
+   * class to use when converting existing js instances into
+   * refract element.
+   */
+  detect: function(test, ElementClass, givenPrepend) {
+    var prepend = givenPrepend === undefined ? true : givenPrepend;
+
+    if (prepend) {
+      this.elementDetection.unshift([test, ElementClass]);
+    } else {
+      this.elementDetection.push([test, ElementClass]);
+    }
+
+    return this;
+  },
+
+  /*
+   * Convert an existing Javascript object into refract element instances, which
+   * can be further processed or serialized into refract or compact refract.
+   * If the item passed in is already refracted, then it is returned
+   * unmodified.
+   */
+  toElement: function(value) {
+    if (value instanceof this.BaseElement) { return value; }
+
+    var element;
+
+    for(var i = 0; i < this.elementDetection.length; i++) {
+      var test = this.elementDetection[i][0];
+      var ElementClass = this.elementDetection[i][1];
+
+      if (test(value)) {
+        element = new ElementClass(value);
+        break;
+      }
+    }
+
+    return element;
+  },
+
+  /*
+   * Get an element class given an element name.
+   */
+  getElementClass: function(element) {
+    var ElementClass = this.elementMap[element];
+
+    if (ElementClass === undefined) {
+      // Fall back to the base element. We may not know what
+      // to do with the `content`, but downstream software
+      // may know.
+      return this.BaseElement;
+    }
+
+    return ElementClass;
+  },
+
+  /*
+   * Convert a long-form refract document into refract element instances.
+   */
+   fromRefract: function(doc) {
+    var ElementClass = this.getElementClass(doc.element);
+    return new ElementClass().fromRefract(doc);
+  },
+
+  /*
+   * Convert a compact refract tuple into refract element instances.
+   */
+  fromCompactRefract: function(tuple) {
+    var ElementClass = this.getElementClass(tuple[0]);
+    return new ElementClass().fromCompactRefract(tuple);
+  }
+});
+
+module.exports = {
+  ElementRegistry: ElementRegistry
+};

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var uptown = require('uptown');
 var createClass = uptown.createClass;
 

--- a/test/converters-test.js
+++ b/test/converters-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('./spec-helper').expect;
-var minim = require('../lib/minim');
+var minim = require('../lib/minim').init();
 
 describe('Minim Converters', function() {
   describe('convertToElement', function() {

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('ArrayElement', function() {
   context('value methods', function() {

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('BaseElement', function() {
   context('when initializing', function() {

--- a/test/primitives/boolean-element-test.js
+++ b/test/primitives/boolean-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('BooleanElement', function() {
   var booleanElement;

--- a/test/primitives/member-element-test.js
+++ b/test/primitives/member-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('MemberElement', function() {
   var member = new minim.MemberElement('foo', 'bar', {}, { foo: 'bar' });

--- a/test/primitives/null-element-test.js
+++ b/test/primitives/null-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('NullElement', function() {
   var nullElement;

--- a/test/primitives/number-element-test.js
+++ b/test/primitives/number-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('NumberElement', function() {
   var numberElement;

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('ObjectElement', function() {
   var objectElement;

--- a/test/primitives/string-element-test.js
+++ b/test/primitives/string-element-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('../spec-helper').expect;
-var minim = require('../../lib/minim');
+var minim = require('../../lib/minim').init();
 
 describe('StringElement', function() {
   var stringElement;

--- a/test/registry-test.js
+++ b/test/registry-test.js
@@ -1,6 +1,6 @@
 var expect = require('./spec-helper').expect;
 var minim = require('../lib/minim');
-var ElementRegistry = require('../lib/base').ElementRegistry;
+var ElementRegistry = require('../lib/registry').ElementRegistry;
 
 describe('Minim registry', function() {
   var registry = new ElementRegistry();

--- a/test/registry-test.js
+++ b/test/registry-test.js
@@ -4,6 +4,7 @@ var ElementRegistry = require('../lib/base').ElementRegistry;
 
 describe('Minim registry', function() {
   var registry = new ElementRegistry();
+  registry.BaseElement = minim.BaseElement;
 
   describe('#register', function() {
     it('should add to the element map', function() {

--- a/test/registry-test.js
+++ b/test/registry-test.js
@@ -1,10 +1,14 @@
 var expect = require('./spec-helper').expect;
-var minim = require('../lib/minim');
 var ElementRegistry = require('../lib/registry').ElementRegistry;
 
 describe('Minim registry', function() {
-  var registry = new ElementRegistry();
-  registry.BaseElement = minim.BaseElement;
+  var registry;
+  var minim;
+
+  before(function() {
+    registry = new ElementRegistry();
+    minim = require('../lib/base').init(registry);
+  });
 
   describe('#register', function() {
     it('should add to the element map', function() {
@@ -21,17 +25,25 @@ describe('Minim registry', function() {
   });
 
   describe('#detect', function() {
-    var test = function() { return true; }
-    registry.elementDetection = [[test, minim.NullElement]];
+    var detectRegistry;
+    var test;
+
+    before(function() {
+      test = function() { return true; }
+
+      // Need a custom registry so we don't cause other tests to fail
+      detectRegistry = new ElementRegistry();
+      detectRegistry.elementDetection = [[test, minim.NullElement]];
+    });
 
     it('should prepend by default', function() {
-      registry.detect(test, minim.StringElement);
-      expect(registry.elementDetection[0][1]).to.equal(minim.StringElement);
+      detectRegistry.detect(test, minim.StringElement);
+      expect(detectRegistry.elementDetection[0][1]).to.equal(minim.StringElement);
     });
 
     it('should be able to append', function() {
-      registry.detect(test, minim.ObjectElement, false);
-      expect(registry.elementDetection[2][1]).to.equal(minim.ObjectElement);
+      detectRegistry.detect(test, minim.ObjectElement, false);
+      expect(detectRegistry.elementDetection[2][1]).to.equal(minim.ObjectElement);
     });
   });
 

--- a/test/registry-test.js
+++ b/test/registry-test.js
@@ -1,5 +1,5 @@
 var expect = require('./spec-helper').expect;
-var ElementRegistry = require('../lib/registry').ElementRegistry;
+var ElementRegistry = require('../lib/minim').ElementRegistry;
 
 describe('Minim registry', function() {
   var registry;

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -3,17 +3,20 @@ var expect = require('./spec-helper').expect;
 var minim = require('../lib/minim');
 
 describe('Minim subclasses', function() {
-  // TODO: Provide better interface for extending elements
-  var MyElement = function() {
-    minim.StringElement.apply(this, arguments);
-    this.element = 'myElement';
-    this._attributeElementKeys = ['headers'];
-  }
+  var MyElement;
 
-  MyElement.prototype = _.create(minim.StringElement.prototype, {
-    ownMethod: function() {
-      return 'It works!';
-    }
+  before(function() {
+    MyElement = minim.StringElement.extend({
+      constructor: function() {
+        minim.StringElement.apply(this, arguments);
+        this.element = 'myElement';
+        this._attributeElementKeys = ['headers'];
+      },
+
+      ownMethod: function() {
+        return 'It works!';
+      }
+    });
   });
 
   it('can extend the base element with its own method', function() {
@@ -22,7 +25,11 @@ describe('Minim subclasses', function() {
   });
 
   context('when initializing', function() {
-    var myElement = new MyElement();
+    var myElement;
+
+    before(function() {
+      myElement = new MyElement();
+    });
 
     it('can overwrite the element name', function() {
       expect(myElement.element).to.equal('myElement');
@@ -34,23 +41,27 @@ describe('Minim subclasses', function() {
   });
 
   describe('deserializing attributes', function() {
-    var myElement = new MyElement().fromRefract({
-      element: 'myElement',
-      attributes: {
-        headers: {
-          element: 'array',
-          content: [
-            {
-              element: 'string',
-              meta: {
-                name: 'Content-Type'
-              },
-              content: 'application/json'
-            }
-          ]
-        },
-        foo: 'bar'
-      }
+    var myElement;
+
+    before(function() {
+      myElement = new MyElement().fromRefract({
+        element: 'myElement',
+        attributes: {
+          headers: {
+            element: 'array',
+            content: [
+              {
+                element: 'string',
+                meta: {
+                  name: 'Content-Type'
+                },
+                content: 'application/json'
+              }
+            ]
+          },
+          foo: 'bar'
+        }
+      });
     });
 
     it('should create headers element instance', function() {
@@ -63,9 +74,13 @@ describe('Minim subclasses', function() {
   });
 
   describe('serializing attributes', function() {
-    var myElement = new MyElement();
-    myElement.attributes.set('headers', new minim.ArrayElement(['application/json']));
-    myElement.attributes.get('headers').content[0].meta.set('name', 'Content-Type');
+    var myElement;
+
+    before(function() {
+      myElement = new MyElement();
+      myElement.attributes.set('headers', new minim.ArrayElement(['application/json']));
+      myElement.attributes.get('headers').content[0].meta.set('name', 'Content-Type');
+    });
 
     it('should serialize headers element', function() {
       var refracted = myElement.toCompactRefract();

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
 var expect = require('./spec-helper').expect;
-var minim = require('../lib/minim');
+var minim = require('../lib/minim').init();
 
 describe('Minim subclasses', function() {
   var MyElement;


### PR DESCRIPTION
With the current implementation in master, there is no way to have a custom registry. This is because we initialize a registry and then every primitive element closures around it. When this happens, any time a new custom registry is used, the original elements will not know about that new registry.

To fix this, we have to generate new elements for each registry. It also requires changing the interface to expose the new registry.

One other thing we could do would be to have `minim.common` or `minim.global` as a kind of global registry that simply calls `init()` on require (and is subsequently cached).

@danielgtaylor Let me know what you think. Sorry about this interface change, but I think it's necessary.
