### PR TITLE
Add a toValue() method to member elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Add a `.toValue()` method to member elements which returns a tuple of the
+  key and value.
+
 # 0.10.0 - 2015-08-18
 
 - Rename the `class` metadata property to `classes`. The convenience property

--- a/lib/primitives/member-element.js
+++ b/lib/primitives/member-element.js
@@ -12,6 +12,10 @@ module.exports = function(BaseElement, registry) {
       this.element = 'member';
     },
 
+    toValue: function () {
+      return [this.key.toValue(), this.value.toValue()];
+    },
+
     toRefract: function() {
       return {
         element: this.element,

--- a/test/primitives/member-element-test.js
+++ b/test/primitives/member-element-test.js
@@ -14,6 +14,12 @@ describe('MemberElement', function() {
     expect(member.attributes.get('foo').toValue()).to.equal('bar');
   });
 
+  describe('#toValue', function () {
+    it('returns a tuple of (key, value)', function () {
+      expect(member.toValue()).to.deep.equal(['foo', 'bar']);
+    });
+  });
+
   describe('#toRefract', function() {
     it('returns the correct Refract value', function() {
       expect(member.toRefract()).to.deep.equal({


### PR DESCRIPTION
This is useful for elements that aren't objects but that use members, for example HTTP headers in the API Description namespace. The element is an array of member elements, and when converted to a js value it would be nice to get out an array of tuples.

cc @smizell 
