### PR TITLE
Add namespace.elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+- Add an `elements` property to the `Namespace` class which returns an object of PascalCased element name keys to registered element class values. This allows for ES6 use cases like:
+
+  ```js
+  const {StringElement, ArrayElement, ObjectElement} = namespace.elements;
+  ```
+
 # 0.11.0 - 2015-09-07
 
 - **BREAKING** The public interface of the `minim` module has changed significantly. List of changes:

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -160,6 +160,29 @@ var Namespace = createClass({
     var ElementClass = this.getElementClass(tuple[0]);
     return new ElementClass().fromCompactRefract(tuple);
   }
+}, {}, {
+  /*
+   * Get an object that contains all registered element classes, where
+   * the key is the PascalCased element name and the value is the class.
+   */
+  elements: {
+    get: function() {
+      var name, pascal;
+      var elements = {
+        BaseElement: this.BaseElement
+      };
+
+      for (name in this.elementMap) {
+        // Currently, all registered element types use a camelCaseName.
+        // Converting to PascalCase is as simple as upper-casing the first
+        // letter.
+        pascal = name[0].toUpperCase() + name.substr(1);
+        elements[pascal] = this.elementMap[name];
+      }
+
+      return elements;
+    }
+  }
 });
 
 module.exports = Namespace;

--- a/test/namespace-test.js
+++ b/test/namespace-test.js
@@ -147,4 +147,31 @@ describe('Minim namespace', function() {
       expect(namespace.getElementClass('unknown')).to.equal(namespace.BaseElement);
     });
   });
+
+  describe('#elements', function() {
+    it('should contain registered element classes', function () {
+      var elements = namespace.elements;
+
+      var elementValues = Object.keys(elements).map(function (name) {
+        return elements[name];
+      });
+      elementValues.shift();
+
+      var mapValues = Object.keys(namespace.elementMap).map(function (name) {
+        return namespace.elementMap[name];
+      });
+
+      expect(elementValues).to.deep.equal(mapValues);
+    });
+
+    it('should use pascal casing', function () {
+      for (var name in namespace.elements) {
+        expect(name[0]).to.equal(name[0].toUpperCase());
+      }
+    });
+
+    it('should contain the base element', function () {
+      expect(namespace.elements.BaseElement).to.equal(namespace.BaseElement);
+    });
+  });
 });


### PR DESCRIPTION
As suggested on another [code review](https://github.com/refractproject/minim-parse-result/pull/1#discussion_r38936177):

Add an `elements` property to the `Namespace` class which returns an object of PascalCased element name keys to registered element class values. This allows for ES6 use cases like:

``` js
const {StringElement, ArrayElement, ObjectElement} = namespace.elements;
```

Possible future improvements:
- Pascal casing mechanism may need to be updated if we ever use non-camel-cased element names.
- Cache the value until an element is registered or unregistered?
  - Build the cache as elements are added or on demand when `namespace.elements` is used?

cc @smizell 
