### PR TITLE
Allow for load when using a plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Allow `load` to be used for plugins where a namespace is not being used
 - Add an `elements` property to the `Namespace` class which returns an object of PascalCased element name keys to registered element class values. This allows for ES6 use cases like:
 
   ```js

--- a/README.md
+++ b/README.md
@@ -613,6 +613,23 @@ var plugin = {
 minim.use(plugin);
 ```
 
+The `load` property may be used in addition to the `namespace` property when a plugin is not implementing a namespace.
+
+```javascript
+var minim = require('minim').namespace();
+
+// Define your plugin module (normally done in a separate file)
+var plugin = {
+  load: function(options) {
+    // Plugin code here
+    return base;
+  }
+}
+
+// Load the plugin
+minim.use(plugin);
+```
+
 ### Chaining
 
 Methods may also be chained when using getters and setters.

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -31,7 +31,7 @@ var Namespace = createClass({
     if (plugin.namespace) {
       plugin.namespace({base: this});
     }
-    else if (plugin.load) {
+    if (plugin.load) {
       plugin.load({base: this});
     }
     return this;

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -25,10 +25,15 @@ var Namespace = createClass({
   },
 
   /*
-   * Use a namespace plugin.
+   * Use a namespace plugin or load a generic plugin.
    */
   use: function(plugin) {
-    plugin.namespace({base: this});
+    if (plugin.namespace) {
+      plugin.namespace({base: this});
+    }
+    else if (plugin.load) {
+      plugin.load({base: this});
+    }
     return this;
   },
 

--- a/test/namespace-test.js
+++ b/test/namespace-test.js
@@ -43,7 +43,7 @@ describe('Minim namespace', function() {
   });
 
   describe('#use', function() {
-    it('can load a plugin module', function() {
+    it('can load a plugin module using the namespace property', function() {
       var plugin = {
         namespace: function(options) {
           var base = options.base;
@@ -56,6 +56,21 @@ describe('Minim namespace', function() {
       namespace.use(plugin);
 
       expect(namespace.elementMap).to.have.property('null2', NullElement);
+    });
+
+    it('can load a plugin module using the load property', function() {
+      var plugin = {
+        load: function(options) {
+          var base = options.base;
+
+          // Register a new element
+          base.register('null3', NullElement);
+        }
+      };
+
+      namespace.use(plugin);
+
+      expect(namespace.elementMap).to.have.property('null3', NullElement);
     });
   });
 


### PR DESCRIPTION
There are many times where a Minim library may not be implementing a namespace.
When this is the case, the `namespace` property does not make semantic sense
for the plugin. This commit implements a `load` property that works just like
the `namespace` property works.
