### PR TITLE
Allow elements to define attribute lists of refracted elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-# Unreleased
+# 0.12.0 - 2015-11-23
 
+- Provide a way for elements to mark attributes as unrefracted arrays of
+  refracted elements. Subclassed elements can push onto the
+  `_attributeElementArrayKeys` property to use this feature. **Note**: in the
+  future this feature may go away.
 - Allow `load` to be used for plugins where a namespace is not being used
 - Add an `elements` property to the `Namespace` class which returns an object of PascalCased element name keys to registered element class values. This allows for ES6 use cases like:
 

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -18,7 +18,11 @@ module.exports = function(registry) {
       }
 
       this.content = content !== undefined ? content : null;
+
+      // The following mark certain keys as being refracted when serialized
+      // instead of just calling `.toValue()` on them.
       this._attributeElementKeys = [];
+      this._attributeElementArrayKeys = [];
     },
 
     primitive: function() {
@@ -65,6 +69,12 @@ module.exports = function(registry) {
         var key = keys[i];
         if (this._attributeElementKeys.indexOf(key) !== -1) {
           attributes[key] = this.attributes.get(key)[functionName]();
+        } else if (this._attributeElementArrayKeys.indexOf(key) !== -1) {
+          attributes[key] = [];
+          var items = this.attributes.get(key);
+          for (var j = 0; j < items.length; j++) {
+            attributes[key].push(items.get(j)[functionName]());
+          }
         } else {
           attributes[key] = this.attributes.get(key).toValue();
         }
@@ -79,11 +89,28 @@ module.exports = function(registry) {
      * method handles the actual conversion when loading.
      */
     convertAttributesToElements: function(conversionFunc) {
-      for (var i = 0; i < this._attributeElementKeys.length; i++) {
-        var key = this._attributeElementKeys[i];
+      var i, key;
+
+      for (i = 0; i < this._attributeElementKeys.length; i++) {
+        key = this._attributeElementKeys[i];
 
         if (this.attributes.hasKey(key)) {
           this.attributes.set(key, conversionFunc(this.attributes.get(key).toValue()));
+        }
+      }
+
+      for (i = 0; i < this._attributeElementArrayKeys.length; i++) {
+        key = this._attributeElementArrayKeys[i];
+
+        if (this.attributes.hasKey(key)) {
+          var items = this.attributes.get(key);
+          var converted = [];
+
+          for (var j = 0; j < items.length; j++) {
+            converted.push(conversionFunc(items.get(j).toValue()));
+          }
+
+          this.attributes.set(key, converted);
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -11,6 +11,7 @@ describe('Minim subclasses', function() {
     StringElement.apply(this, arguments);
     this.element = 'myElement';
     this._attributeElementKeys = ['headers'];
+    this._attributeElementArrayKeys = ['sourceMap'];
   }
 
   MyElement.prototype = _.create(StringElement.prototype, {
@@ -52,7 +53,13 @@ describe('Minim subclasses', function() {
             }
           ]
         },
-        foo: 'bar'
+        foo: 'bar',
+        sourceMap: [
+          {
+            element: 'string',
+            content: 'test'
+          }
+        ]
       }
     });
 
@@ -63,12 +70,22 @@ describe('Minim subclasses', function() {
     it('should leave foo alone', function() {
       expect(myElement.attributes.get('foo').toValue()).to.be.a('string');
     });
+
+    it('should create array of source map elements', function() {
+      var sourceMaps = myElement.attributes.get('sourceMap');
+      expect(sourceMaps).to.have.length(1);
+      expect(sourceMaps.first()).to.be.instanceOf(StringElement);
+      expect(sourceMaps.first().toValue()).to.equal('test');
+    });
   });
 
   describe('serializing attributes', function() {
     var myElement = new MyElement();
+
     myElement.attributes.set('headers', new ArrayElement(['application/json']));
     myElement.attributes.get('headers').content[0].meta.set('name', 'Content-Type');
+
+    myElement.attributes.set('sourceMap', ['string1', 'string2']);
 
     it('should serialize headers element', function() {
       var refracted = myElement.toCompactRefract();
@@ -76,7 +93,11 @@ describe('Minim subclasses', function() {
       expect(refracted).to.deep.equal(['myElement', {}, {
         headers: ['array', {}, {}, [
             ['string', {name: 'Content-Type'}, {}, 'application/json']
-        ]]
+        ]],
+        sourceMap: [
+          ['string', {}, {}, 'string1'],
+          ['string', {}, {}, 'string2']
+        ]
       }, null]);
     });
   });


### PR DESCRIPTION
This creates a new variable that can be used to define the attribute key names which are made up of non-refracted lists of refracted elements, such as [source maps](https://github.com/refractproject/refract-spec/blob/master/namespaces/parse-result-namespace.md#source-map-element). It adds a test to the subclassing example to maintain code coverage. Since the `sourceMap` element isn't defined I have created the test with an array of string elements instead. Serialization and deserialization work for both full and compact refract.

This change will allow me to update the parse result namespace and unblock some development of source maps. The other potential blocker is how to treat e.g. `element.meta.title` as an element with a source map rather than a string, but let's leave that for another PR.

cc @smizell 
