### PR TITLE
Fix a bug when loading compact refract attributes; bump to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.1 - 2015-11-24
+
+- Fix a bug when loading refracted attributes from compact refract.
+
 # 0.12.0 - 2015-11-23
 
 - Provide a way for elements to mark attributes as unrefracted arrays of

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -137,7 +137,7 @@ module.exports = function(registry) {
       this.content = tuple[3];
 
       this.convertAttributesToElements(function(attribute) {
-        registry.fromCompactRefract(attribute);
+        return registry.fromCompactRefract(attribute);
       });
 
       if (this.element !== tuple[0]) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -100,5 +100,10 @@ describe('Minim subclasses', function() {
         ]
       }, null]);
     });
+
+    it('should round-trip', function() {
+      const refracted = myElement.toCompactRefract();
+      expect(myElement.fromCompactRefract(refracted).toCompactRefract()).to.deep.equal(refracted);
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue where the missing `return` statement was causing attributes to be set to `undefined`, which in turn causes issues when serializing. This is required for source map support to work properly with compact refract.

cc @smizell 
