### PR TITLE
Allow registering default attribute element keys on a registry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.2 - 2015-11-24
+
+- Fix a bug related to setting the default key names that should be treated as refracted elements in element attributes. This is now accomplished via the namespace: `namespace._elementAttributeKeys.push('my-value');`. This fixes bugs related to overwriting the `namespace.BaseElement`.
+
 # 0.12.1 - 2015-11-24
 
 - Fix a bug when loading refracted attributes from compact refract.

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -22,6 +22,10 @@ var Namespace = createClass({
     if (!options || !options.noDefault) {
       this.useDefault();
     }
+
+    // These provide the defaults for new elements.
+    this._attributeElementKeys = [];
+    this._attributeElementArrayKeys = [];
   },
 
   /*

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -21,8 +21,8 @@ module.exports = function(registry) {
 
       // The following mark certain keys as being refracted when serialized
       // instead of just calling `.toValue()` on them.
-      this._attributeElementKeys = [];
-      this._attributeElementArrayKeys = [];
+      this._attributeElementKeys = registry._attributeElementKeys.concat([]);
+      this._attributeElementArrayKeys = registry._attributeElementArrayKeys.concat([]);
     },
 
     primitive: function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/namespace-test.js
+++ b/test/namespace-test.js
@@ -3,11 +3,11 @@ var minim = require('../lib/minim');
 var Namespace = require('../lib/namespace');
 
 describe('Minim namespace', function() {
-  var namespace = new Namespace();
-
+  var namespace;
   var ArrayElement, NullElement, ObjectElement, StringElement;
 
   beforeEach(function() {
+    namespace = new Namespace();
     namespace.elementMap = {};
     namespace.elementDetection = [];
     namespace.useDefault();
@@ -24,6 +24,16 @@ describe('Minim namespace', function() {
 
   it('gets returned from minim.namespace()', function() {
     expect(minim.namespace()).to.be.an.instanceof(Namespace);
+  });
+
+  it('can set default refracted attributes', function() {
+    namespace._attributeElementKeys.push('foo');
+    namespace._attributeElementArrayKeys.push('bar');
+
+    var instance = new StringElement('');
+
+    expect(instance._attributeElementKeys).to.deep.equal(['foo']);
+    expect(instance._attributeElementArrayKeys).to.deep.equal(['bar']);
   });
 
   describe('default elements', function() {


### PR DESCRIPTION
Version bump to 0.12.2.

Turns out I accidentally broke Minim when using the parse result namespace package. It would overwrite the `namespace.BaseElement` and later down the line checks for things like `ArrayElement` being an instance of the new `BaseElement` would fail (since it is an instance of the _original, pre-replaced_ `BaseElement`), wreaking havoc and resulting in huge, ridiculously difficult to debug refracted messes. :cry:

This fixes the issue by providing a value on the `namespace` that can be used to add default key names, which bypasses the need to overwrite the `BaseElement`. I was hoping to avoid this but I can't seem to come up with any other decent solution. Unfortunately we don't have a good way to overwrite the `BaseElement` at the moment, and I believe such a feature would require changes to the public interface so that existing elements could be re-registered using the new base.

Sorry for the code churn :facepunch: 

cc @smizell 
