### PR TITLE
Implement support for optionally refracted metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- When an element in `meta` has its own metadata or attributes defined then it will now be refracted when calling `toRefract` or `toCompactRefract`.
+- When loading from refract or compact refract, if an item in `meta` looks like an element it will be loaded as such. This may cause false positives.
+
 # 0.12.2 - 2015-11-24
 
 - Fix a bug related to setting the default key names that should be treated as refracted elements in element attributes. This is now accomplished via the namespace: `namespace._elementAttributeKeys.push('my-value');`. This fixes bugs related to overwriting the `namespace.BaseElement`.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ var stringElement2 = minim.fromEmbeddedRefract({
 });
 ```
 
+Note that due to optional refracting in `meta`, anything that looks like an element in the given serialization will be loaded as such.
+
 ### Extending elements
 
 You can extend elements using the `extend` static method.
@@ -152,6 +154,8 @@ var arrayValue = arrayElement.toValue(); // [1, 2, 3]
 
 The `toRefract` method returns the Refract value of the Minim element.
 
+Note that if any element in `meta` has metadata or attributes defined that would be lost by calling `toValue()` then that element is also converted to refract.
+
 ```javascript
 var arrayElement = minim.toElement([1, 2, 3]);
 var refract = arrayElement.toRefract(); // See converting to elements above
@@ -160,6 +164,8 @@ var refract = arrayElement.toRefract(); // See converting to elements above
 #### toCompactRefract
 
 The `toCompactRefract` method returns the Compact Refract value of the Minim element.
+
+Note that if any element in `meta` has metadata or attributes defined that would be lost by calling `toValue()` then that element is also converted to compact refract.
 
 ```javascript
 var stringElement = minim.toElement("foobar");

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -42,9 +42,10 @@ module.exports = function(registry) {
 
     toRefract: function(options) {
       var attributes = this.convertAttributesToRefract('toRefract');
+      var meta = this.convertMetaToRefract('toRefract');
       var initial = {
         element: this.element,
-        meta: this.meta.toValue(),
+        meta: meta,
         attributes: attributes,
         content: this.content
       };
@@ -53,7 +54,27 @@ module.exports = function(registry) {
 
     toCompactRefract: function() {
       var attributes = this.convertAttributesToRefract('toCompactRefract');
-      return [this.element, this.meta.toValue(), attributes, this.content];
+      var meta = this.convertMetaToRefract('toCompactRefract');
+      return [this.element, meta, attributes, this.content];
+    },
+
+    /*
+     * Converts everything in `meta` into values, unless any top-level element
+     * contains additional metadata or attributes, in which case it gets
+     * refracted.
+     */
+    convertMetaToRefract: function(functionName) {
+      var meta = {};
+      this.meta.keys().forEach(function (key) {
+        var item = this.meta.get(key);
+        if (item.meta.keys().length || item.attributes.keys().length) {
+          // Additional information, so we need to refract this element!
+          meta[key] = item[functionName]();
+        } else {
+          meta[key] = item.toValue();
+        }
+      }, this);
+      return meta;
     },
 
     /*
@@ -116,9 +137,21 @@ module.exports = function(registry) {
     },
 
     fromRefract: function(doc) {
-      this.meta = doc.meta;
       this.attributes = doc.attributes;
       this.content = doc.content;
+
+      if (doc.meta) {
+        Object.keys(doc.meta).forEach(function (key) {
+          var value = doc.meta[key];
+
+          // TODO: Warning - this may raise a false positive :-(
+          if (value.element) {
+            this.meta.set(key, registry.fromRefract(value));
+          } else {
+            this.meta.set(key, value);
+          }
+        }, this);
+      }
 
       this.convertAttributesToElements(function(attribute) {
         return registry.fromRefract(attribute);
@@ -132,9 +165,21 @@ module.exports = function(registry) {
     },
 
     fromCompactRefract: function(tuple) {
-      this.meta = tuple[1];
       this.attributes = tuple[2];
       this.content = tuple[3];
+
+      if (tuple[1]) {
+        Object.keys(tuple[1]).forEach(function (key) {
+          var value = tuple[1][key];
+
+          // TODO: Warning - this may raise a false positive :-(
+          if (value && value.length === 4 && _.isString(value[0]) && _.isObject(value[1]) && _.isObject(value[2])) {
+            this.meta.set(key, registry.fromCompactRefract(value));
+          } else {
+            this.meta.set(key, value);
+          }
+        }, this);
+      }
 
       this.convertAttributesToElements(function(attribute) {
         return registry.fromCompactRefract(attribute);

--- a/test/primitives/boolean-element-test.js
+++ b/test/primitives/boolean-element-test.js
@@ -7,7 +7,7 @@ var BooleanElement = minim.getElementClass('boolean');
 describe('BooleanElement', function() {
   var booleanElement;
 
-  before(function() {
+  beforeEach(function() {
     booleanElement = new BooleanElement(true);
   });
 
@@ -30,23 +30,86 @@ describe('BooleanElement', function() {
   });
 
   describe('#toRefract', function() {
-    var expected = {
-      element: 'boolean',
-      meta: {},
-      attributes: {},
-      content: true
-    };
+    var expected;
 
     it('returns a boolean element', function() {
+      expected = {
+        element: 'boolean',
+        meta: {},
+        attributes: {},
+        content: true
+      };
+
+      expect(booleanElement.toRefract()).to.deep.equal(expected);
+    });
+
+    it('includes extra metadata if present', function() {
+      expected = {
+        element: 'boolean',
+        meta: {
+          id: {
+            element: 'string',
+            meta: {},
+            attributes: {
+              someExtraData: true
+            },
+            content: 'abc'
+          }
+        },
+        attributes: {},
+        content: true
+      };
+      booleanElement.meta.set('id', 'abc');
+      booleanElement.meta.get('id').attributes.set('someExtraData', true);
       expect(booleanElement.toRefract()).to.deep.equal(expected);
     });
   });
 
   describe('#toCompactRefract', function() {
-    var expected = ['boolean', {}, {}, true];
+    var expected;
 
     it('returns a boolean Compact element', function() {
+      expected = ['boolean', {}, {}, true]
       expect(booleanElement.toCompactRefract()).to.deep.equal(expected);
+    });
+
+    it('includes extra metadata if present', function() {
+      expected = ['boolean', {
+        id: ['string', {}, {someExtraData: true}, 'abc']
+      }, {}, true];
+      booleanElement.meta.set('id', 'abc');
+      booleanElement.meta.get('id').attributes.set('someExtraData', true);
+      expect(booleanElement.toCompactRefract()).to.deep.equal(expected);
+    });
+  });
+
+  describe('#fromRefract', function() {
+    it('can handle optionally refracted metadata', function() {
+      booleanElement.fromRefract({
+        element: 'boolean',
+        meta: {
+          id: {
+            element: 'string',
+            meta: {},
+            attributes: {},
+            content: 'abc'
+          }
+        },
+        attributes: {},
+        content: true
+      });
+
+      expect(booleanElement.meta.get('id').toValue()).to.equal('abc');
+    });
+  });
+
+  describe('#fromCompactRefract', function() {
+    it('can handle optionally refracted metadata', function() {
+      booleanElement.fromCompactRefract(['boolean', {
+        id: ['string', {}, {}, 'abc']
+      }, {}, true]);
+
+      expect(booleanElement.meta.get('id').toValue()).to.equal('abc');
     });
   });
 


### PR DESCRIPTION
This is a stab at supporting optional refracting like you see with source maps in Minim, particularly in the `meta` property of an element. This means we will now support `element.meta.id`, `element.meta.title` and `element.meta.description` metadata that includes source maps, both for serialization and for loading from refract or compact refract.

There is a (tiny) chance of false positives with the heuristics during loading. It is unlikely since we control the structure of what goes into `meta`.

If this PR is merged, it unblocks basic source map support in Minim element metadata, which is currently just being thrown away during serialization and causes fairly useless behavior when loading.

cc @smizell 
