### PR TITLE
Call toValue when adding items to the serialized array

### DIFF
--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -79,7 +79,7 @@ module.exports = function(registry) {
             if (subItem.meta.keys().length || subItem.attributes.keys().length) {
               values.push(subItem[functionName]());
             } else {
-              values.push(subItem);
+              values.push(subItem.toValue());
             }
           }
           meta[key] = values;


### PR DESCRIPTION
This is required to not break support down the line in other packages, e.g. when elements have arrays of non-refracted stuff like `element.meta.classes`.

cc @smizell 
