### PR TITLE
Allow querying the element tree recursively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "6"
   - "4"
-  - "0.12"
-  - "0.10"
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- Elements now provide a `findRecursive` method allowing you to recursively
+  find matching elements.
+
 # 0.15.0 - 2017-04-03
 
 - Getters of link element will now return an element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+## Breaking
+
+- Node 0.10 and 0.12 are no longer supported.
+
 ## Enhancements
 
 - Elements now provide a `findRecursive` method allowing you to recursively

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ element including the parents of the returned element.
 
 As an example, if I had an array element which contains a category element
 which in turn contains a string element with the content "Hello World". I can
-access the parent array and category element.
+access the parent array and category element. The parents are in closest parent
+order.
 
 ```json
 {
@@ -244,10 +245,10 @@ access the parent array and category element.
 const elements = element.findRecursive('string');
 const helloString = elements.first();
 
-// Array Element
+// Category Element
 helloString.parents[0];
 
-// Category Element
+// Array Element
 helloString.parents[1];
 ```
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,26 @@ arrayElement.forEach(function(item) {
 }); // logs each value to console
 ```
 
+##### shift
+
+The `shift` method may be used to remove an item from the start of a Minim array.
+
+```javascript
+var arrayElement = minim.toElement(['a', 'b', 'c']);
+var element = arrayElement.shift();
+console.log(element.toValue()); // a
+```
+
+##### unshift
+
+The `unshift` method may be used to inserts items to the start of a Minim array.
+
+```javascript
+var arrayElement = minim.toElement(['a', 'b', 'c']);
+arrayElement.unshift('d');
+console.log(arrayElement.toValue()); // ['d', 'a', 'b', 'c']
+```
+
 ##### push
 
 The `push` method may be used to add items to a Minim array.

--- a/README.md
+++ b/README.md
@@ -195,13 +195,21 @@ var stringElement = minim.toElement("foobar");
 var stringElementClone = stringElement.clone();
 ```
 
-#### recursiveFind
+#### findRecursive
 
 Recursively find an element. Returns an ArrayElement containing all elements
 that match the given element name.
 
 ```javascript
-const strings = element.recursiveFind('string');
+const strings = element.findRecursive('string');
+```
+
+You can pass multiple element names to `findRecursive`. The method will
+search for the last given element name inside elements matching the other
+given element names.
+
+```javascript
+const stringInsideMembers = element.findRecursive('member', 'string');
 ```
 
 **NOTE:** *The returned elements contain a `parents` property which includes

--- a/README.md
+++ b/README.md
@@ -204,16 +204,52 @@ that match the given element name.
 const strings = element.findRecursive('string');
 ```
 
-You can pass multiple element names to `findRecursive`. The method will
-search for the last given element name inside elements matching the other
-given element names.
+You may pass multiple element names to `findRecursive`. When multiple element
+names are passed down, minim will only find an element that is found within
+the other given elements. For example, we can pass in `member` and `string` so
+that we are recursively looking for all `string` elements that are found within a
+`member` element:
 
 ```javascript
 const stringInsideMembers = element.findRecursive('member', 'string');
 ```
 
-**NOTE:** *The returned elements contain a `parents` property which includes
-all of the elements parent in the original Refract tree.*
+##### Parents
+
+Each returned element will include a new `parents` property which is an array
+element including the parents of the returned element.
+
+As an example, if I had an array element which contains a category element
+which in turn contains a string element with the content "Hello World". I can
+access the parent array and category element.
+
+```json
+{
+  "element": "array",
+  "content": [
+    {
+      "element": "category",
+      "content": [
+        {
+          "element": "string",
+          "content": "Hello World"
+        }
+      ]
+    }
+  ]
+}
+```
+
+```javascript
+const elements = element.findRecursive('string');
+const helloString = elements.first();
+
+// Array Element
+helloString.parents[0];
+
+// Category Element
+helloString.parents[1];
+```
 
 ### Minim Elements
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,15 @@ var stringElementClone = stringElement.clone();
 
 #### recursiveFind
 
-Recursively find an element.
+Recursively find an element. Returns an ArrayElement containing all elements
+that match the given element name.
 
 ```javascript
 const strings = element.recursiveFind('string');
 ```
+
+**NOTE:** *The returned elements contain a `parents` property which includes
+all of the elements parent in the original Refract tree.*
 
 ### Minim Elements
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ var stringElement = minim.toElement("foobar");
 var stringElementClone = stringElement.clone();
 ```
 
+#### recursiveFind
+
+Recursively find an element.
+
+```javascript
+const strings = element.recursiveFind('string');
+```
+
 ### Minim Elements
 
 Minim supports the following primitive elements

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -164,7 +164,7 @@ var Namespace = createClass({
   /*
    * Convert a refract document into refract element instances.
    */
-   fromRefract: function(doc) {
+  fromRefract: function(doc) {
     var ElementClass = this.getElementClass(doc.element);
     return new ElementClass().fromRefract(doc);
   }

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -118,6 +118,14 @@ module.exports = function(BaseElement, registry) {
       });
     },
 
+    shift: function() {
+      return this.content.shift();
+    },
+
+    unshift: function(value) {
+      this.content.unshift(registry.toElement(value));
+    },
+
     push: function(value) {
       this.content.push(registry.toElement(value));
       return this;

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -49,29 +49,29 @@ module.exports = function(registry) {
         parents = new ArrayElement();
       }
 
-      const elementName = elementNames.pop();
+      var elementName = elementNames.pop();
 
       parents.push(this);
 
-      const append = function(array, element) {
+      var append = function(array, element) {
         array.push(element);
         return array;
-      }
+      };
 
-      const attachParents = function(element, parents) {
-        const clonedElement = element.clone();
+      var attachParents = function(element, parents) {
+        var clonedElement = element.clone();
         clonedElement.parents = parents;
         return clonedElement;
-      }
+      };
 
       // Checks the given element and appends element/sub-elements
       // that match element name to given array
-      const checkElement = function(array, element) {
+      var checkElement = function(array, element) {
         if (element.element === elementName) {
           array.push(attachParents(element, parents));
         }
 
-        const items = element.findRecursive(elementName, parents);
+        var items = element.findRecursive(elementName, parents);
         if (items) {
           items.reduce(append, array);
         }
@@ -106,12 +106,14 @@ module.exports = function(registry) {
 
       if (elementNames.length > 0) {
         array = array.filter(function (element) {
-          const parentElements = element.parents.map(function (element) {
+          var parentElements = element.parents.map(function (element) {
             return element.element;
           }).reverse();
 
-          for (const name of elementNames) {
-            const index = parentElements.indexOf(name);
+          for (var namesIndex in elementNames) {
+            var name = elementNames[namesIndex];
+            var index = parentElements.indexOf(name);
+
             if (index !== -1) {
               parentElements.splice(0, index);
             } else {

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -35,6 +35,60 @@ module.exports = function(registry) {
       return this.content;
     },
 
+    /// Finds the given elements in the element tree
+    /// Returns ArrayElement of elements or null
+    findRecursive: function(elementName) {
+      var ArrayElement = registry.getElementClass('array');
+      var array = new ArrayElement();
+
+      const append = function(array, element) {
+        array.push(element);
+        return array;
+      }
+
+      // Checks the given element and appends element/sub-elements
+      // that match element name to given array
+      const checkElement = function(array, element) {
+        if (element.element === elementName) {
+          array.push(element);
+        }
+
+        const items = element.findRecursive(elementName);
+        if (items) {
+          items.reduce(append, array);
+        }
+
+        // Key-Value Pair
+        if (element.key) {
+          checkElement(array, element.key);
+        }
+
+        if (element.value) {
+          checkElement(array, element.value);
+        }
+
+        return array;
+      };
+
+      if (this.content) {
+        // Direct Element
+        if (this.content.element) {
+          checkElement(array, this.content);
+        }
+
+        // Element Array
+        if (this.content.constructor === Array) {
+          this.content.reduce(checkElement, array);
+        }
+      }
+
+      if (array.length > 0) {
+        return array;
+      }
+
+      return null;
+    },
+
     shouldRefract: function (element) {
       if (element.element !== element.primitive() || element.element === 'member') {
         return true;

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -37,23 +37,38 @@ module.exports = function(registry) {
 
     /// Finds the given elements in the element tree
     /// Returns ArrayElement of elements or null
-    findRecursive: function(elementName) {
+    findRecursive: function(elementName, inheritedParents) {
       var ArrayElement = registry.getElementClass('array');
       var array = new ArrayElement();
+      var parents;
+
+      if (inheritedParents === undefined) {
+        parents = new ArrayElement();
+      } else {
+        parents = inheritedParents.clone();
+      }
+
+      parents.push(this);
 
       const append = function(array, element) {
         array.push(element);
         return array;
       }
 
+      const attachParents = function(element, parents) {
+        const clonedElement = element.clone();
+        clonedElement.parents = parents;
+        return clonedElement;
+      }
+
       // Checks the given element and appends element/sub-elements
       // that match element name to given array
       const checkElement = function(array, element) {
         if (element.element === elementName) {
-          array.push(element);
+          array.push(attachParents(element, parents));
         }
 
-        const items = element.findRecursive(elementName);
+        const items = element.findRecursive(elementName, parents);
         if (items) {
           items.reduce(append, array);
         }

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -36,7 +36,7 @@ module.exports = function(registry) {
     },
 
     /// Finds the given elements in the element tree
-    /// Returns ArrayElement of elements or null
+    /// Returns ArrayElement of elements
     /// findRecursive: function(names..., parents)
     findRecursive: function() {
       var elementNames = [].concat.apply([], arguments);
@@ -126,11 +126,7 @@ module.exports = function(registry) {
         });
       }
 
-      if (array.length > 0) {
-        return array;
-      }
-
-      return null;
+      return array;
     },
 
     shouldRefract: function (element) {

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -37,16 +37,19 @@ module.exports = function(registry) {
 
     /// Finds the given elements in the element tree
     /// Returns ArrayElement of elements or null
-    findRecursive: function(elementName, inheritedParents) {
+    findRecursive: function() {
+      var elementNames = [].concat.apply([], arguments);
       var ArrayElement = registry.getElementClass('array');
       var array = new ArrayElement();
       var parents;
 
-      if (inheritedParents === undefined) {
-        parents = new ArrayElement();
+      if (elementNames[elementNames.length - 1].element === 'array') {
+        parents = elementNames.pop().clone();
       } else {
-        parents = inheritedParents.clone();
+        parents = new ArrayElement();
       }
+
+      const elementName = elementNames.pop();
 
       parents.push(this);
 
@@ -73,6 +76,8 @@ module.exports = function(registry) {
           items.reduce(append, array);
         }
 
+        parents.push(element);
+
         // Key-Value Pair
         if (element.key) {
           checkElement(array, element.key);
@@ -81,6 +86,8 @@ module.exports = function(registry) {
         if (element.value) {
           checkElement(array, element.value);
         }
+
+        parents.content.pop();
 
         return array;
       };
@@ -92,9 +99,28 @@ module.exports = function(registry) {
         }
 
         // Element Array
-        if (this.content.constructor === Array) {
+        if (Array.isArray(this.content)) {
           this.content.reduce(checkElement, array);
         }
+      }
+
+      if (elementNames.length > 0) {
+        array = array.filter(function (element) {
+          const parentElements = element.parents.map(function (element) {
+            return element.element;
+          }).reverse();
+
+          for (const name of elementNames) {
+            const index = parentElements.indexOf(name);
+            if (index !== -1) {
+              parentElements.splice(0, index);
+            } else {
+              return false;
+            }
+          }
+
+          return true;
+        });
       }
 
       if (array.length > 0) {

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -52,7 +52,7 @@ module.exports = function(registry) {
 
       var elementName = elementNames.pop();
 
-      parents.push(this);
+      parents.unshift(this);
 
       var append = function(array, element) {
         array.push(element);
@@ -77,7 +77,7 @@ module.exports = function(registry) {
           items.reduce(append, array);
         }
 
-        parents.push(element);
+        parents.unshift(element);
 
         // Key-Value Pair
         if (element.key) {
@@ -88,7 +88,7 @@ module.exports = function(registry) {
           checkElement(array, element.value);
         }
 
-        parents.content.pop();
+        parents.shift();
 
         return array;
       };
@@ -109,7 +109,7 @@ module.exports = function(registry) {
         array = array.filter(function (element) {
           var parentElements = element.parents.map(function (element) {
             return element.element;
-          }).reverse();
+          });
 
           for (var namesIndex in elementNames) {
             var name = elementNames[namesIndex];

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -37,6 +37,7 @@ module.exports = function(registry) {
 
     /// Finds the given elements in the element tree
     /// Returns ArrayElement of elements or null
+    /// findRecursive: function(names..., parents)
     findRecursive: function() {
       var elementNames = [].concat.apply([], arguments);
       var ArrayElement = registry.getElementClass('array');

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "coveralls": "^2.11.2",
-    "eslint": "^0.21.2",
+    "eslint": "^3.0.0",
     "istanbul": "^0.3.14",
     "karma": "^0.13.3",
     "karma-browserify": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   "dependencies": {
     "lodash": "^4.15.0",
     "uptown": "^0.4.1"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -211,8 +211,24 @@ describe('ArrayElement', function() {
       expect(instance.get(4).toValue()).to.equal('foobar');
     };
 
+    describe('#shift', function() {
+      it('removes an item from the start of an array', function() {
+        var shifted = arrayElement.shift();
+        expect(arrayElement.length).to.equal(3);
+        expect(shifted.toValue()).to.equal('a');
+      });
+    });
+
+    describe('#unshift', function() {
+      it('adds a new item to the start of the array', function() {
+        arrayElement.unshift('foobar');
+        expect(arrayElement.length).to.equal(5);
+        expect(arrayElement.get(0).toValue()).to.equal('foobar');
+      });
+    });
+
     describe('#push', function() {
-      it('adds a new item to the array', function() {
+      it('adds a new item to the end of the array', function() {
         arrayElement.push('foobar');
         itAddsToArray(arrayElement);
       });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -231,4 +231,111 @@ describe('BaseElement', function() {
       });
     });
   });
+
+  context('when querying', function() {
+    it('returns null when there are no matching elements', function() {
+      const element = new minim.BaseElement();
+      const result = element.findRecursive('string');
+
+      expect(result).to.equal(null);
+    });
+
+    it('finds direct element', function() {
+      const StringElement = minim.getElementClass('string');
+      const element = new minim.BaseElement(
+        new StringElement('Hello World')
+      );
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['Hello World']);
+    });
+
+    it('finds direct element inside array', function() {
+      const ArrayElement = minim.getElementClass('array');
+      const StringElement = minim.getElementClass('string');
+      const NumberElement = minim.getElementClass('number');
+      const element = new ArrayElement([
+        new StringElement('One'),
+        new NumberElement(2),
+        new StringElement('Three'),
+      ]);
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['One', 'Three']);
+    });
+
+    it('finds direct element inside object', function() {
+      const ObjectElement = minim.getElementClass('object');
+      const MemberElement = minim.getElementClass('member');
+      const StringElement = minim.getElementClass('string');
+      const NumberElement = minim.getElementClass('number');
+
+      const element = new ObjectElement();
+      element.push(new MemberElement(new StringElement('key1'), new NumberElement(1)));
+      element.push(new MemberElement(new NumberElement(2), new StringElement('value2')));
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['key1', 'value2']);
+    });
+
+    it('finds non-direct element inside element', function() {
+      const StringElement = minim.getElementClass('string');
+
+      const element = new minim.BaseElement(
+        new minim.BaseElement(
+          new StringElement('Hello World')
+        )
+      );
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['Hello World']);
+    });
+
+    it('finds non-direct element inside array', function() {
+      const StringElement = minim.getElementClass('string');
+      const ArrayElement = minim.getElementClass('array');
+
+      const element = new minim.BaseElement(
+        new ArrayElement([
+          new StringElement('Hello World')
+        ])
+      );
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['Hello World']);
+    });
+
+    it('finds non-direct element inside object', function() {
+      const ObjectElement = minim.getElementClass('object');
+      const ArrayElement = minim.getElementClass('array');
+      const MemberElement = minim.getElementClass('member');
+      const StringElement = minim.getElementClass('string');
+      const NumberElement = minim.getElementClass('number');
+
+      const element = new ObjectElement();
+      element.push(new MemberElement(
+        new ArrayElement([new StringElement('key1')]),
+        new NumberElement(1)
+      ));
+      element.push(new MemberElement(
+        new NumberElement(2),
+        new ArrayElement([new StringElement('value2')])
+      ));
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['key1', 'value2']);
+    });
+  });
 });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -357,7 +357,7 @@ describe('BaseElement', function() {
       const parentIDs = helloElement.parents.map(function (item) {
         return item.id.toValue();
       });
-      expect(parentIDs).to.deep.equal(['Outter', 'Inner']);
+      expect(parentIDs).to.deep.equal(['Inner', 'Outter']);
     });
 
     it('finds elements contained in given elements', function () {

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -359,5 +359,30 @@ describe('BaseElement', function() {
       });
       expect(parentIDs).to.deep.equal(['Outter', 'Inner']);
     });
+
+    it('finds elements contained in given elements', function () {
+      const StringElement = minim.getElementClass('string');
+      const ArrayElement = minim.getElementClass('array');
+      const ObjectElement = minim.getElementClass('object');
+      const MemberElement = minim.getElementClass('member');
+
+      const object = new ObjectElement();
+      object.push(new MemberElement(
+        new StringElement('Three'),
+        new ArrayElement([
+          new StringElement('Four')
+        ])
+      ));
+
+      const element = new ArrayElement([
+        new StringElement('One'),
+        object
+      ]);
+
+      const result = element.findRecursive('member', 'array', 'string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['Four']);
+    });
   });
 });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -337,5 +337,27 @@ describe('BaseElement', function() {
       expect(result.element).to.equal('array');
       expect(result.toValue()).to.deep.equal(['key1', 'value2']);
     });
+
+    it('attaches parent tree to found objects', function () {
+      const StringElement = minim.getElementClass('string');
+      const ArrayElement = minim.getElementClass('array');
+
+      const hello = new StringElement('Hello World')
+      const array = new ArrayElement([hello]);
+      const element = new ArrayElement([array]);
+      array.id = 'Inner';
+      element.id = 'Outter';
+
+      const result = element.findRecursive('string');
+
+      expect(result.element).to.equal('array');
+      expect(result.toValue()).to.deep.equal(['Hello World']);
+
+      const helloElement = result.first();
+      const parentIDs = helloElement.parents.map(function (item) {
+        return item.id.toValue();
+      });
+      expect(parentIDs).to.deep.equal(['Outter', 'Inner']);
+    });
   });
 });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -233,11 +233,11 @@ describe('BaseElement', function() {
   });
 
   context('when querying', function() {
-    it('returns null when there are no matching elements', function() {
+    it('returns empty array when there are no matching elements', function() {
       const element = new minim.BaseElement();
       const result = element.findRecursive('string');
 
-      expect(result).to.equal(null);
+      expect(result.length).to.equal(0);
     });
 
     it('finds direct element', function() {


### PR DESCRIPTION
Recursively find an element. Returns an ArrayElement containing all elements that match the given element name.

```javascript
const strings = element.findRecursive('string');
```

You can pass multiple element names to `findRecursive`. The method will search for the last given element name inside elements matching the other given element names.

```javascript
const stringInsideMembers = element.findRecursive('member', 'string');
```

**NOTE:** *The returned elements contain a `parents` property which includes all of the elements parent in the original Refract tree.*

The `parents` property is injected in just like mentioned in https://github.com/refractproject/minim/issues/17

**Recommended to review per commit.**