### PR TITLE
Remove element.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Breaking
 
 - Node 0.10 and 0.12 are no longer supported.
+- Elements `name` property was removed. There is no longer a name property in
+  Refract specification.
 
 ## Enhancements
 

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -312,17 +312,6 @@ module.exports = function(registry) {
       }
     },
 
-    // TODO: Remove, not in Refract spec
-    // Requires updating subclass test
-    name: {
-      get: function() {
-        return this.getMetaProperty('name', '');
-      },
-      set: function(element) {
-        this.setMetaProperty('name', element);
-      }
-    },
-
     title: {
       get: function() {
         return this.getMetaProperty('title', '');


### PR DESCRIPTION
There is no `name` meta property in the Refract spec..