### PR TITLE
Support `parent` property on all elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# Master
+
+## Breaking
+
+- `findRecursive` now returns an array instead of an `ArrayElement`.
+- The parents on the elements returned by `findRecursive` are no longer an
+  `ArrayElement`.
+
+## Enhancements
+
+- Element now contains a `parent` property which may be set to an elements
+  parent element.
+- Element has a `parents` property returning all of the parent elements of an
+  element.
+
 # 0.16.0 - 2017-05-04
 
 ## Breaking

--- a/README.md
+++ b/README.md
@@ -195,34 +195,18 @@ var stringElement = minim.toElement("foobar");
 var stringElementClone = stringElement.clone();
 ```
 
-#### findRecursive
+##### parent
 
-Recursively find an element. Returns an ArrayElement containing all elements
-that match the given element name.
-
-```javascript
-const strings = element.findRecursive('string');
-```
-
-You may pass multiple element names to `findRecursive`. When multiple element
-names are passed down, minim will only find an element that is found within
-the other given elements. For example, we can pass in `member` and `string` so
-that we are recursively looking for all `string` elements that are found within a
-`member` element:
+Returns the elements parent element. This will be undefined if the element was
+not added as a child of another element.
 
 ```javascript
-const stringInsideMembers = element.findRecursive('member', 'string');
+var parent = element.parent;
 ```
 
-##### Parents
+##### parents
 
-Each returned element will include a new `parents` property which is an array
-element including the parents of the returned element.
-
-As an example, if I had an array element which contains a category element
-which in turn contains a string element with the content "Hello World". I can
-access the parent array and category element. The parents are in closest parent
-order.
+Returns the complete parent hierachy as an array.
 
 ```json
 {
@@ -242,14 +226,30 @@ order.
 ```
 
 ```javascript
-const elements = element.findRecursive('string');
-const helloString = elements.first();
-
 // Category Element
-helloString.parents[0];
+helloWorld.parents[0];
 
 // Array Element
-helloString.parents[1];
+helloWorld.parents[1];
+```
+
+#### findRecursive
+
+Recursively find an element. Returns an array containing all elements
+that match the given element name.
+
+```javascript
+const strings = element.findRecursive('string');
+```
+
+You may pass multiple element names to `findRecursive`. When multiple element
+names are passed down, minim will only find an element that is found within
+the other given elements. For example, we can pass in `member` and `string` so
+that we are recursively looking for all `string` elements that are found within a
+`member` element:
+
+```javascript
+const stringInsideMembers = element.findRecursive('member', 'string');
 ```
 
 ### Minim Elements

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -10,6 +10,11 @@ module.exports = function(BaseElement, registry) {
       });
       BaseElement.call(this, convertedContent, meta || {}, attributes || {});
       this.element = 'array';
+
+      var element = this;
+      convertedContent.forEach(function (child) {
+        child.parent = element;
+      });
     },
 
     primitive: function() {
@@ -31,11 +36,17 @@ module.exports = function(BaseElement, registry) {
     },
 
     fromRefract: function(doc) {
-      return BaseElement.prototype.fromRefract.call(this, doc, {
+      var element = BaseElement.prototype.fromRefract.call(this, doc, {
         content: (doc.content || []).map(function(content) {
           return registry.fromRefract(content);
         })
       });
+
+      element.content.forEach(function (child) {
+        child.parent = element;
+      });
+
+      return element;
     },
 
     get: function(index) {
@@ -129,15 +140,21 @@ module.exports = function(BaseElement, registry) {
     },
 
     shift: function() {
-      return this.content.shift();
+      var element = this.content.shift();
+      element.parent = undefined;
+      return element;
     },
 
     unshift: function(value) {
-      this.content.unshift(registry.toElement(value));
+      var element = registry.toElement(value);
+      element.parent = this;
+      this.content.unshift(element);
     },
 
     push: function(value) {
-      this.content.push(registry.toElement(value));
+      var element = registry.toElement(value);
+      element.parent = this;
+      this.content.push(element);
       return this;
     },
 

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -37,47 +37,29 @@ module.exports = function(registry) {
 
     /// Finds the given elements in the element tree
     /// Returns ArrayElement of elements
-    /// findRecursive: function(names..., parents)
+    /// findRecursive: function(names...)
     findRecursive: function() {
       var elementNames = [].concat.apply([], arguments);
-      var ArrayElement = registry.getElementClass('array');
-      var array = new ArrayElement();
-      var parents;
-
-      if (elementNames[elementNames.length - 1].element === 'array') {
-        parents = elementNames.pop().clone();
-      } else {
-        parents = new ArrayElement();
-      }
+      var array = [];
 
       var elementName = elementNames.pop();
-
-      parents.unshift(this);
 
       var append = function(array, element) {
         array.push(element);
         return array;
       };
 
-      var attachParents = function(element, parents) {
-        var clonedElement = element.clone();
-        clonedElement.parents = parents;
-        return clonedElement;
-      };
-
       // Checks the given element and appends element/sub-elements
       // that match element name to given array
       var checkElement = function(array, element) {
         if (element.element === elementName) {
-          array.push(attachParents(element, parents));
+          array.push(element);
         }
 
-        var items = element.findRecursive(elementName, parents);
+        var items = element.findRecursive(elementName);
         if (items) {
           items.reduce(append, array);
         }
-
-        parents.unshift(element);
 
         // Key-Value Pair
         if (element.key) {
@@ -87,8 +69,6 @@ module.exports = function(registry) {
         if (element.value) {
           checkElement(array, element.value);
         }
-
-        parents.shift();
 
         return array;
       };
@@ -116,7 +96,7 @@ module.exports = function(registry) {
             var index = parentElements.indexOf(name);
 
             if (index !== -1) {
-              parentElements.splice(0, index);
+              parentElements = parentElements.splice(0, index);
             } else {
               return false;
             }
@@ -258,6 +238,20 @@ module.exports = function(registry) {
       this.meta.set(name, value);
     }
   }, {}, {
+    parents: {
+      get: function() {
+        var parents = [];
+
+        var parent = this.parent;
+        while (parent) {
+          parents.push(parent);
+          parent = parent.parent;
+        }
+
+        return parents;
+      }
+    },
+
     element: {
       get: function() {
         // Returns 'element' so we don't have undefined as element

--- a/lib/primitives/member-element.js
+++ b/lib/primitives/member-element.js
@@ -10,6 +10,14 @@ module.exports = function(BaseElement, registry) {
 
       BaseElement.call(this, content, meta, attributes);
       this.element = 'member';
+
+      if (content.key) {
+        content.key.parent = this;
+      }
+
+      if (content.value) {
+        content.value.parent = this;
+      }
     },
 
     toValue: function () {
@@ -42,7 +50,12 @@ module.exports = function(BaseElement, registry) {
         return this.content.key;
       },
       set: function(key) {
+        if (this.content.key) {
+          this.content.key.parent = undefined;
+        }
+
         this.content.key = registry.toElement(key);
+        this.content.key.parent = this;
       }
     },
 
@@ -51,7 +64,12 @@ module.exports = function(BaseElement, registry) {
         return this.content.value;
       },
       set: function(value) {
+        if (this.content.value) {
+          this.content.value.parent = undefined;
+        }
+
         this.content.value = registry.toElement(value);
+        this.content.value.parent = this;
       }
     }
   });

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -50,6 +50,7 @@ module.exports = function(BaseElement, ArrayElement, MemberElement) {
 
       this.content = this.content.filter(function (item) {
         if (item.key.toValue() === name) {
+          item.parent = undefined;
           removed = item;
           return false;
         }
@@ -91,7 +92,7 @@ module.exports = function(BaseElement, ArrayElement, MemberElement) {
       if (member) {
         member.value = value;
       } else {
-        this.content.push(new MemberElement(key, value));
+        this.push(new MemberElement(key, value));
       }
 
       return this;

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -20,6 +20,25 @@ describe('ArrayElement', function() {
       setArray();
     });
 
+    describe('#constructor', function() {
+      it('sets content element parent to element', function() {
+        var element = new ArrayElement(['Hello World']);
+        var child = element.get(0);
+
+        expect(child.parent).to.equal(element);
+      });
+    });
+
+    describe('#fromRefract', function() {
+      it('sets content element parent to element', function() {
+        var element = minim.fromRefract({element: 'array', content: ['Hello World']});
+        var child = element.get(0);
+
+        expect(child.parent).to.equal(element);
+      });
+    });
+
+
     describe('.content', function() {
       var correctElementNames;
       var storedElementNames;
@@ -236,6 +255,11 @@ describe('ArrayElement', function() {
         expect(arrayElement.length).to.equal(3);
         expect(shifted.toValue()).to.equal('a');
       });
+
+      it('unsets removed items parent', function() {
+        var shifted = arrayElement.shift();
+        expect(shifted.parent).to.be.undefined;
+      });
     });
 
     describe('#unshift', function() {
@@ -244,6 +268,13 @@ describe('ArrayElement', function() {
         expect(arrayElement.length).to.equal(5);
         expect(arrayElement.get(0).toValue()).to.equal('foobar');
       });
+
+      it('sets parent of added element', function() {
+        arrayElement.unshift('foobar');
+        var element = arrayElement.get(0);
+
+        expect(element.parent).to.equal(arrayElement);
+      });
     });
 
     describe('#push', function() {
@@ -251,12 +282,27 @@ describe('ArrayElement', function() {
         arrayElement.push('foobar');
         itAddsToArray(arrayElement);
       });
+
+      it('sets parent of added element', function() {
+        arrayElement.push('foobar');
+        var element = arrayElement.get(4);
+
+        expect(element.parent).to.equal(arrayElement);
+      });
     });
 
     describe('#add', function() {
       it('adds a new item to the array', function() {
         arrayElement.add('foobar');
         itAddsToArray(arrayElement);
+      });
+
+
+      it('sets parent of added element', function() {
+        arrayElement.push('foobar');
+        var element = arrayElement.get(4);
+
+        expect(element.parent).to.equal(arrayElement);
       });
     });
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -91,6 +91,24 @@ describe('BaseElement', function() {
     })
   });
 
+  describe('#parents', function() {
+    it('returns no parents when no parents', function() {
+      var element = new minim.BaseElement();
+      expect(element.parents.length).to.equal(0);
+    });
+
+    it('returns parents when there are present parents', function() {
+      var element1 = new minim.BaseElement('one');
+      var element2 = new minim.BaseElement('two');
+      var element3 = new minim.BaseElement('three');
+
+      element1.parent = element2;
+      element2.parent = element3;
+
+      expect(element1.parents).to.deep.equal([element2, element3]);
+    });
+  });
+
   describe('#equals', function() {
     var el;
 
@@ -280,8 +298,8 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['Hello World']);
+      expect(result.length).to.equal(1);
+      expect(result[0].toValue()).to.deep.equal('Hello World');
     });
 
     it('finds direct element inside array', function() {
@@ -296,8 +314,9 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['One', 'Three']);
+      expect(result.length).to.equal(2);
+      expect(result[0].toValue()).to.deep.equal('One');
+      expect(result[1].toValue()).to.deep.equal('Three');
     });
 
     it('finds direct element inside object', function() {
@@ -312,8 +331,9 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['key1', 'value2']);
+      expect(result.length).to.equal(2);
+      expect(result[0].toValue()).to.deep.equal('key1');
+      expect(result[1].toValue()).to.deep.equal('value2');
     });
 
     it('finds non-direct element inside element', function() {
@@ -327,8 +347,8 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['Hello World']);
+      expect(result.length).to.equal(1);
+      expect(result[0].toValue()).to.deep.equal('Hello World');
     });
 
     it('finds non-direct element inside array', function() {
@@ -343,8 +363,8 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['Hello World']);
+      expect(result.length).to.equal(1);
+      expect(result[0].toValue()).to.deep.equal('Hello World');
     });
 
     it('finds non-direct element inside object', function() {
@@ -366,15 +386,16 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['key1', 'value2']);
+      expect(result.length).to.equal(2);
+      expect(result[0].toValue()).to.deep.equal('key1');
+      expect(result[1].toValue()).to.deep.equal('value2');
     });
 
     it('attaches parent tree to found objects', function () {
       const StringElement = minim.getElementClass('string');
       const ArrayElement = minim.getElementClass('array');
 
-      const hello = new StringElement('Hello World')
+      const hello = new StringElement('Hello World');
       const array = new ArrayElement([hello]);
       const element = new ArrayElement([array]);
       array.id = 'Inner';
@@ -382,10 +403,10 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['Hello World']);
+      expect(result.length).to.equal(1);
+      expect(result[0].toValue()).to.deep.equal('Hello World');
 
-      const helloElement = result.first();
+      const helloElement = result[0];
       const parentIDs = helloElement.parents.map(function (item) {
         return item.id.toValue();
       });
@@ -413,8 +434,8 @@ describe('BaseElement', function() {
 
       const result = element.findRecursive('member', 'array', 'string');
 
-      expect(result.element).to.equal('array');
-      expect(result.toValue()).to.deep.equal(['Four']);
+      expect(result.length).to.equal(1);
+      expect(result[0].toValue()).to.deep.equal('Four');
     });
   });
 });

--- a/test/primitives/member-element-test.js
+++ b/test/primitives/member-element-test.js
@@ -5,7 +5,11 @@ var minim = require('../../lib/minim').namespace();
 var MemberElement = minim.getElementClass('member');
 
 describe('MemberElement', function() {
-  var member = new MemberElement('foo', 'bar', {}, { foo: 'bar' });
+  var member;
+
+  beforeEach(function() {
+    member = new MemberElement('foo', 'bar', {}, { foo: 'bar' });
+  });
 
   it('correctly sets the key and value', function() {
     expect(member.key.toValue()).to.equal('foo');
@@ -14,6 +18,34 @@ describe('MemberElement', function() {
 
   it('correctly sets the attributes', function() {
     expect(member.attributes.get('foo').toValue()).to.equal('bar');
+  });
+
+  describe('#key', function() {
+    it('sets keys parent during setter', function() {
+      member.key = 'Hello';
+      expect(member.key.parent).to.equal(member);
+    });
+
+    it('unsets existing keys parent during setter', function() {
+      var existingKey = member.key;
+      member.key = 'Hello';
+
+      expect(existingKey.parent).to.be.undefined;
+    });
+  });
+
+  describe('#value', function() {
+    it('sets value parent during setter', function() {
+      member.value = 'Hello';
+      expect(member.value.parent).to.equal(member);
+    });
+
+    it('unsets existing valuess parent during setter', function() {
+      var existingValue = member.value;
+      member.value = 'Hello';
+
+      expect(existingValue.parent).to.be.undefined;
+    });
   });
 
   describe('#toValue', function () {


### PR DESCRIPTION
This PR adds a `parent` property on an element which is set to a parent when a child is added to a collection. For example, when I set a key of a member the keys parent is set to the member.

See README and CHANGELOG changes in PR diff for more details.

Implements #17.