### PR TITLE
Provide element classes in public interface

### DIFF
--- a/lib/minim.js
+++ b/lib/minim.js
@@ -9,3 +9,13 @@ exports.Namespace = Namespace;
 exports.namespace = function namespace(options) {
   return new Namespace(options);
 };
+
+exports.BaseElement = require('./primitives/base-element');
+exports.StringElement = require('./primitives/string-element');
+exports.NumberElement = require('./primitives/number-element');
+exports.BooleanElement = require('./primitives/boolean-element');
+exports.NullElement = require('./primitives/null-element');
+exports.ArrayElement = require('./primitives/array-element');
+exports.ObjectElement = require('./primitives/object-element');
+exports.MemberElement = require('./primitives/member-element');
+exports.LinkElement = require('./elements/link-element');


### PR DESCRIPTION
This pull request provides the element classes as apart of the minim public interface. This makes it easier for other libraries to include and extend specific elements without having to be wrapped in a namespace.

As an example, in minim-api-description could be simplified:

##### After

```js
import { BaseElement } from 'minim';

export default class Asset extends BaseElement {}
```

```js
import Asset from './elements/asset';

export function namespace(options) {
  options.base.register('asset', Asset);
}

export default { namespace, Asset };
```

##### Before

```js
export default function (namespace) {
  class Asset extends namespace.BaseElement {}

  namespace.register('asset', Asset);
}
```

```js
import asset from './elements/asset';

export function namespace(options) {
  asset(options.base);
}

export default { namespace };
```