### PR TITLE
Support children and recursiveChildren on all elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@
   provides a convenience `toRefract(element)` and `fromRefract(object)`
   methods.
 
+- `ArrayElement` `children` method has been replaced by a `children` property
+  on all elements. You may now chain children in conjunction with `filter` to
+  get the existing behaviour.
+
+  Before:
+
+  ```js
+  const numbers = doc.children((element) => element.element == 'number');
+  ```
+
+  After:
+
+  ```js
+  const numbers = doc.children.filter((element) => element.element == 'number');
+  ```
+
+  *OR*
+
+  ```js
+  const numbers = doc.children.findByElement('number');
+  ```
+
+## Enhancements
+
+- All elements now contain a `children` and `recursiveChildren` properties that
+  return an ArrayElement of the respective children elements.
+
 # 0.16.0 - 2017-05-04
 
 ## Breaking

--- a/README.md
+++ b/README.md
@@ -241,6 +241,36 @@ helloString.parents[0];
 helloString.parents[1];
 ```
 
+#### children
+
+The `children` property returns an `ArrayElement` containing all of the direct children elements.
+
+```javascript
+var arrayElement = minim.toElement(['a', [1, 2], 'b', 3]);
+var numbers = arrayElement.children(function(el) {
+  return el.element === 'number';
+}).toValue(); // [3]
+```
+
+#### recursiveChildren
+
+The `recursiveChildren` property returns an `ArrayElement` containing all of the children elements recursively.
+
+```javascript
+var arrayElement = minim.toElement(['a', [1, 2], 'b', 3]);
+var children = arrayElement.recursiveChildren;
+children.toValue(); // ['a', 1, 2, 'b', 3]
+```
+
+##### Chaining
+
+```javascript
+var evenNumbers = array
+  .recursiveChildren
+  .findByElement('number')
+  .filter((element) => element.toValue() % 2)
+```
+
 ### Minim Elements
 
 Minim supports the following primitive elements
@@ -479,19 +509,6 @@ The `findByClass` method traverses the entire descendent element tree and return
 ##### findByElement
 
 The `findByElement` method traverses the entire descendent element tree and returns an `ArrayElement` of all elements that match the given element name.
-
-##### children
-
-The `children` method traverses direct descendants and returns an `ArrayElement` of all elements that match the condition function given.
-
-```javascript
-var arrayElement = minim.toElement(['a', [1, 2], 'b', 3]);
-var numbers = arrayElement.children(function(el) {
-  return el.element === 'number';
-}).toValue(); // [3]
-```
-
-Because only children are tested with the condition function, the values `[1, 2]` are seen as an `array` type whose content is never tested. Thus, the only direct child which is a number element is `3`.
 
 ##### getById
 

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -171,15 +171,6 @@ var ArrayElement = BaseElement.extend({
   },
 
   /*
-   * Search all direct descendents using a condition function.
-   */
-  children: function(condition) {
-    var newArray = new ArrayElement();
-    newArray.content = this.findElements(condition, {recursive: false});
-    return newArray;
-  },
-
-  /*
    * Search the tree recursively and find the element with the matching ID
    */
   getById: function(id) {

--- a/lib/primitives/base-element.js
+++ b/lib/primitives/base-element.js
@@ -275,6 +275,45 @@ var BaseElement = createClass({
     set: function(element) {
       this.setMetaProperty('links', element);
     }
+  },
+
+  children: {
+    get: function() {
+      var ArrayElement = require('./array-element');
+
+      if (Array.isArray(this.content)) {
+        return new ArrayElement(this.content);
+      } else if (this.content instanceof KeyValuePair) {
+        var children = new ArrayElement([this.content.key]);
+
+        if (this.content.value) {
+          children.push(this.content.value);
+        }
+
+        return children;
+      } else if (this.content instanceof BaseElement) {
+        return new ArrayElement([this.content]);
+      } else {
+        return new ArrayElement();
+      }
+    }
+  },
+
+  recursiveChildren: {
+    get: function() {
+      var ArrayElement = require('./array-element');
+      var children = new ArrayElement();
+
+      this.children.forEach(function (element) {
+        children.push(element);
+
+        element.recursiveChildren.forEach(function (child) {
+          children.push(child);
+        });
+      });
+
+      return children;
+    }
   }
 });
 

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -298,7 +298,7 @@ describe('ArrayElement', function() {
 
     before(function() {
       doc = minim.fromRefract(refract);
-      strings = doc.children(function(el) {
+      strings = doc.children.filter(function(el) {
         return el.element === 'string';
       });
       recursiveStrings = doc.find(function(el) {

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -296,6 +296,89 @@ describe('BaseElement', function() {
     });
   });
 
+  describe('#children', function() {
+    const ArrayElement = minim.getElementClass('array');
+
+    it('returns empty array when content is primitive', function() {
+      const element = new minim.BaseElement('value');
+      const children = element.children;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(0);
+    });
+
+    it('returns a direct child', function() {
+      const child = new minim.BaseElement('value');
+      const element = new minim.BaseElement(child);
+      const children = element.children;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(1);
+      expect(children.get(0)).to.equal(child);
+    });
+
+    it('returns array of direct children', function() {
+      const child1 = new minim.BaseElement('value1');
+      const child2 = new minim.BaseElement('value2');
+
+      const element = new minim.BaseElement([child1, child2]);
+      const children = element.children;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(2);
+      expect(children.get(0)).to.equal(child1);
+      expect(children.get(1)).to.equal(child2);
+    });
+
+    it('returns array of key pair item', function() {
+      const key = new minim.BaseElement('key');
+      const element = new minim.BaseElement(new KeyValuePair(key));
+
+      const children = element.children;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(1);
+      expect(children.get(0)).to.equal(key);
+    });
+
+    it('returns array of key value pair items', function() {
+      const key = new minim.BaseElement('key');
+      const value = new minim.BaseElement('value');
+      const element = new minim.BaseElement(new KeyValuePair(key, value));
+
+      const children = element.children;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(2);
+      expect(children.get(0)).to.equal(key);
+      expect(children.get(1)).to.equal(value);
+    });
+  });
+
+  describe('#recursiveChildren', function() {
+    const ArrayElement = minim.getElementClass('array');
+
+    it('returns empty array when content is primitive', function() {
+      const element = new minim.BaseElement('value');
+      const children = element.recursiveChildren;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(0);
+    });
+
+    it('returns all direct recursive children', function() {
+      const childchild = new minim.BaseElement('value');
+      const child = new minim.BaseElement(childchild);
+      const element = new minim.BaseElement(child);
+      const children = element.recursiveChildren;
+
+      expect(children).to.be.instanceof(ArrayElement);
+      expect(children.length).to.equal(2);
+      expect(children.get(0)).to.equal(child);
+      expect(children.get(1)).to.equal(childchild);
+    });
+  });
+
   context('when querying', function() {
     it('returns empty array when there are no matching elements', function() {
       const element = new minim.BaseElement();


### PR DESCRIPTION
Adds a new `children` and `recursiveChildren` to the base element to return all of the respective children regardless of the element type.

I think we could perhaps explore a special [iterator type](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Iterators_and_Generators) so that `recursiveChildren` can become lazy in the future.