### PR TITLE
Don't serialise empty meta and attributes in JSON serialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - All elements now contain a `children` and `recursiveChildren` properties that
   return an ArrayElement of the respective children elements.
 
+- JSON Serialiser will no longer serialise empty `meta` and `attributes` into
+  JSON objects.
+
 # 0.16.0 - 2017-05-04
 
 ## Breaking

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -10,12 +10,21 @@ module.exports = createClass({
   },
 
   serialise: function(element) {
-    return {
+    var payload = {
       element: element.element,
-      meta: this.serialiseObject(element.meta),
-      attributes: this.serialiseObject(element.attributes),
-      content: this.serialiseContent(element.content)
     };
+
+    if (element.meta.length > 0) {
+      payload['meta'] = this.serialiseObject(element.meta);
+    }
+
+    if (element.attributes.length > 0) {
+      payload['attributes'] = this.serialiseObject(element.attributes);
+    }
+
+    payload['content'] = this.serialiseContent(element.content);
+
+    return payload;
   },
 
   deserialise: function(value) {

--- a/test/namespace-test.js
+++ b/test/namespace-test.js
@@ -176,8 +176,6 @@ describe('Minim namespace', function() {
 
       expect(object).to.deep.equal({
         element: 'string',
-        meta: {},
-        attributes: {},
         content: 'hello'
       });
     });

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -30,8 +30,6 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'string',
-        meta: {},
-        attributes: {},
         content: 'Hello'
       });
     });
@@ -45,12 +43,8 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'custom',
-        meta: {},
-        attributes: {},
         content: {
           element: 'string',
-          meta: {},
-          attributes: {},
           content: 'Hello'
         }
       });
@@ -64,13 +58,9 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'array',
-        meta: {},
-        attributes: {},
         content: [
           {
             element: 'string',
-            meta: {},
-            attributes: {},
             content: 'Hello'
           }
         ]
@@ -83,8 +73,6 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'element',
-        meta: {},
-        attributes: {},
         content: {
           message: 'hello'
         }
@@ -100,19 +88,13 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'member',
-        meta: {},
-        attributes: {},
         content: {
           key: {
             element: 'string',
-            meta: {},
-            attributes: {},
             content: 'name'
           },
           value: {
             element: 'string',
-            meta: {},
-            attributes: {},
             content: 'Doe'
           },
         }
@@ -130,7 +112,6 @@ describe('JSON Serialiser', function() {
         meta: {
           title: 'Name'
         },
-        attributes: {},
         content: 'Doe'
       });
     });
@@ -143,7 +124,6 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'string',
-        meta: {},
         attributes: {
           thread: 123
         },
@@ -159,12 +139,9 @@ describe('JSON Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'string',
-        meta: {},
         attributes: {
           thread: {
             element: 'element',
-            meta: {},
-            attributes: {},
             content: 123
           }
         },

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -90,12 +90,10 @@ describe('Minim subclasses', function() {
 
       expect(refracted).to.deep.equal({
         element: 'myElement',
-        meta: {},
         attributes: {
           headers: [
             {
               element: 'string',
-              attributes: {},
               meta: {
                 name: 'Content-Type'
               },


### PR DESCRIPTION
This aligns behaviour with the Refract spec and other tools.