### PR TITLE
Convert JS objects during "refraction" of JavaScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Bug Fixes
+
+- When converting JavaScript values to Refract, objects are now supported.
+
 # 0.17.0 - 2017-06-16
 
 ## Breaking

--- a/lib/refraction.js
+++ b/lib/refraction.js
@@ -2,13 +2,17 @@
 
 /// Refracts a JSON type to minim elements
 function refract(value) {
+  var Element = require('./primitives/element');
   var ArrayElement = require('./primitives/array-element');
   var NumberElement = require('./primitives/number-element');
   var StringElement = require('./primitives/string-element');
   var BooleanElement = require('./primitives/boolean-element');
   var NullElement = require('./primitives/null-element');
+  var ObjectElement = require('./primitives/object-element');
 
-  if (typeof value === 'string') {
+  if (value instanceof Element) {
+    return value;
+  } else if (typeof value === 'string') {
     return new StringElement(value);
   } else if (typeof value === 'number') {
     return new NumberElement(value);
@@ -18,6 +22,14 @@ function refract(value) {
     return new NullElement();
   } else if (Array.isArray(value)) {
     return new ArrayElement(value.map(refract));
+  } else if (typeof value === 'object') {
+    var element = new ObjectElement();
+
+    for (var key in value) {
+      element.set(key, value[key]);
+    }
+
+    return element;
   }
 
   return value;

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -3,6 +3,7 @@ var expect = require('../spec-helper').expect;
 var minim = require('../../lib/minim').namespace();
 
 var ObjectElement = minim.getElementClass('object');
+var StringElement = minim.getElementClass('string');
 
 describe('ObjectElement', function() {
   var objectElement;
@@ -137,6 +138,15 @@ describe('ObjectElement', function() {
       var obj = new ObjectElement();
       obj.set({ foo: 'bar' });
       expect(obj.get('foo').toValue()).to.equal('bar');
+    });
+
+    it('should refract key and value from object', function() {
+      var obj = new ObjectElement();
+      obj.set('key', 'value');
+      var member = obj.getMember('key');
+
+      expect(member.key).to.be.instanceof(StringElement);
+      expect(member.value).to.be.instanceof(StringElement);
     });
   });
 

--- a/test/refraction-test.js
+++ b/test/refraction-test.js
@@ -1,0 +1,65 @@
+var expect = require('./spec-helper').expect;
+var minim = require('../lib/minim');
+var refract = require('../lib/refraction').refract;
+
+describe('refract', function() {
+  it('returns any given element without refracting', function() {
+    var element = new minim.StringElement('hello');
+    var refracted = refract(element);
+
+    expect(refracted).to.equal(element);
+  });
+
+  it('can refract a string into a string element', function() {
+    var element = refract('Hello');
+
+    expect(element).to.be.instanceof(minim.StringElement);
+    expect(element.content).to.equal('Hello');
+  });
+
+  it('can refract a number into a number element', function() {
+    var element = refract(1);
+
+    expect(element).to.be.instanceof(minim.NumberElement);
+    expect(element.content).to.equal(1);
+  });
+
+  it('can refract a boolean into a boolean element', function() {
+    var element = refract(true);
+
+    expect(element).to.be.instanceof(minim.BooleanElement);
+    expect(element.content).to.equal(true);
+  });
+
+  it('can refract a null value into a null element', function() {
+    var element = refract(null);
+
+    expect(element).to.be.instanceof(minim.NullElement);
+    expect(element.content).to.equal(null);
+  });
+
+  it('can refract an array of values into an array element', function() {
+    var element = refract(['Hi', 1]);
+
+    expect(element).to.be.instanceof(minim.ArrayElement);
+    expect(element.length).to.be.equal(2);
+    expect(element.get(0)).to.be.instanceof(minim.StringElement);
+    expect(element.get(0).content).to.equal('Hi');
+    expect(element.get(1)).to.be.instanceof(minim.NumberElement);
+    expect(element.get(1).content).to.equal(1);
+  });
+
+  it('can refract an object into an object element', function() {
+    var element = refract({'name': 'Doe'});
+
+    expect(element).to.be.instanceof(minim.ObjectElement);
+    expect(element.length).to.equal(1);
+
+    var member = element.content[0];
+    expect(member).to.be.instanceof(minim.MemberElement);
+    expect(member.key).to.be.instanceof(minim.StringElement);
+    expect(member.key.content).to.equal('name');
+    expect(member.value).to.be.instanceof(minim.StringElement);
+    expect(member.value.content).to.equal('Doe');
+  });
+});


### PR DESCRIPTION
The `refract` function is supposed to take any JS type and convert it to a Refract element. The case where the given value was a JS Object it wasn't correctly handled.