### PR TITLE
Fix initialisation of element with meta/attributes elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Initialising an Element with given meta or attributes as ObjectElement is now
+  supported.
+
 # 0.17.0 - 2017-06-16
 
 ## Breaking

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -10,11 +10,11 @@ var Element = createClass({
     // Lazy load this.meta and this.attributes because it's a Minim element
     // Otherwise, we get into circuluar calls
     if (meta) {
-      this.meta.set(meta);
+      this.meta = meta;
     }
 
     if (attributes) {
-      this.attributes.set(attributes);
+      this.attributes = attributes;
     }
 
     this.content = content !== undefined ? content : null;
@@ -229,7 +229,13 @@ var Element = createClass({
       return this._meta;
     },
     set: function(value) {
-      this.meta.set(value || {});
+      var ObjectElement = require('./object-element');
+
+      if (value instanceof ObjectElement) {
+        this._meta = value;
+      } else {
+        this.meta.set(value || {});
+      }
     }
   },
 
@@ -243,7 +249,12 @@ var Element = createClass({
       return this._attributes;
     },
     set: function(value) {
-      this.attributes.set(value || {});
+      var ObjectElement = require('./object-element');
+      if (value instanceof ObjectElement) {
+        this._attributes = value;
+      } else {
+        this.attributes.set(value || {});
+      }
     }
   },
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -6,22 +6,34 @@ var RefElement = require('../../lib/minim').RefElement;
 
 describe('Element', function() {
   context('when initializing', function() {
-    var el;
-
-    before(function() {
-      el = new minim.Element({}, {
+    it('should initialize the correct meta data', function() {
+      var element = new minim.Element({}, {
         id: 'foobar',
         classes: ['a', 'b'],
         title: 'Title',
         description: 'Description'
       });
+
+      expect(element.meta.get('id').toValue()).to.equal('foobar');
+      expect(element.meta.get('classes').toValue()).to.deep.equal(['a', 'b']);
+      expect(element.meta.get('title').toValue()).to.equal('Title');
+      expect(element.meta.get('description').toValue()).to.equal('Description');
     });
 
-    it('should initialize the correct meta data', function() {
-      expect(el.meta.get('id').toValue()).to.equal('foobar');
-      expect(el.meta.get('classes').toValue()).to.deep.equal(['a', 'b']);
-      expect(el.meta.get('title').toValue()).to.equal('Title');
-      expect(el.meta.get('description').toValue()).to.equal('Description');
+    it('should allow initialising with meta object', function() {
+      var meta = new minim.elements.Object();
+      meta.set('id', 'foobar');
+      var element = new minim.Element(null, meta);
+
+      expect(element.meta.get('id').toValue()).to.equal('foobar');
+    });
+
+    it('should allow initialising with attributes object', function() {
+      var attributes = new minim.elements.Object();
+      attributes.set('test', 'foobar');
+      var element = new minim.Element(null, null, attributes);
+
+      expect(element.attributes.get('test').toValue()).to.equal('foobar');
     });
   });
 


### PR DESCRIPTION
When initialising an element passing in a meta or attributes element the JS Object would be refracted in a weird way and converted to object element of object element. This PR fixes that to support passing object element to meta/attributes.