### PR TITLE
Deserialise array as array element in JSON Deserialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Initialising an Element with given meta or attributes as ObjectElement is now
   supported.
 - When converting JavaScript values to Refract, objects are now supported.
+- JSON De-serialisation will now deserialise an array into an ArrayElement
+  instead of plain array.
 
 # 0.17.0 - 2017-06-16
 

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -37,7 +37,8 @@ module.exports = createClass({
     } else if (value === null) {
       return new this.namespace.elements.Null();
     } else if (value.map) {
-      return value.map(this.deserialise, this);
+      var content = value.map(this.deserialise, this);
+      return new this.namespace.elements.Array(content);
     }
 
     var ElementClass = this.namespace.getElementClass(value.element);

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -191,6 +191,14 @@ describe('JSON Serialiser', function() {
       expect(element.content[0].content).to.equal('Hello');
     });
 
+    it('deserialise from a JSON array', function() {
+      var element = serialiser.deserialise([1]);
+
+      expect(element).to.be.instanceof(minim.elements.Array);
+      expect(element.content[0]).to.be.instanceof(minim.elements.Number);
+      expect(element.content[0].content).to.equal(1);
+    });
+
     it('deserialises from a JSON object containing JSON object content', function() {
       var element = serialiser.deserialise({
         element: 'element',


### PR DESCRIPTION
When receiving an array in the deserialisation step. The JSON Deserialiser would only deserialise the contents and provide a plain array of elements back. This change results in returning an array element.