### PR TITLE
Add special case to serialise sourceMap as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Initialising an Element with given meta or attributes as ObjectElement is now
   supported.
 - When converting JavaScript values to Refract, objects are now supported.
+- Adds a special case to serialise sourceMap elements as values.
 
 # 0.17.0 - 2017-06-16
 

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -22,6 +22,11 @@ module.exports = createClass({
       payload['attributes'] = this.serialiseObject(element.attributes);
     }
 
+    if (element.element === 'sourceMap') {
+      payload['content'] = element.toValue();
+      return payload;
+    }
+
     payload['content'] = this.serialiseContent(element.content);
 
     return payload;

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -148,6 +148,22 @@ describe('JSON Serialiser', function() {
         content: 'Hello World'
       });
     });
+
+    it('serialises a sourceMap element as values', function() {
+      var element = new minim.elements.Element(
+        new minim.elements.Array(
+          [new minim.elements.Array([1,2])]
+        )
+      );
+      element.element = 'sourceMap';
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'sourceMap',
+        content: [[1,2]]
+      });
+    });
   });
 
   describe('deserialisation', function() {


### PR DESCRIPTION
Since sourceMap doesn't serialise its content as other element, it has a special rules of its own to serialise a plain array of array. Therefore we can handle the special case by calling `toValue()` on the sourceMap element when serialising sourceMaps.

This PR goes with https://github.com/refractproject/minim-parse-result/pull/20/files#r124780274.

This isn't so elegant, but I don't see a better way to solve the problem with the existing serialisation rules. This rule is already changed in the latest version of the Refract JSON Serialisation and we can remove it going forward when we update serialisation in Minim (moving current implementation to legacy serialiser).