### PR TITLE
Use the latest JSON serialisation rules in Refract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Master
 
+## Breaking
+
+- JSON Serialisation now follows the JSON Refract serialisation rules defined at
+  https://github.com/refractproject/refract-spec/blob/master/formats/json-refract.md.
+
+  Existing serialiser is available during a transition period to aid migration
+  to the new format.
+
+    ```js
+    const JSONSerialiser = require('minim/serialisers/json-0.6');
+    const serialiser = new JSONSerialiser();
+    const element = serialiser.deserialise('Hello');
+    serialiser.serialise(element);
+    ```
+
 ## Enhancements
 
 - ArrayElement high-order functions, `map`, `filter` and `forEach` now accept

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -22,7 +22,11 @@ module.exports = createClass({
       payload['attributes'] = this.serialiseObject(element.attributes);
     }
 
-    payload['content'] = this.serialiseContent(element.content);
+    if (this[element.element + 'SerialiseContent']) {
+      payload['content'] = this[element.element + 'SerialiseContent'](element, payload);
+    } else if (element.content !== undefined) {
+      payload['content'] = this.serialiseContent(element.content);
+    }
 
     return payload;
   },

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -44,6 +44,10 @@ module.exports = createClass({
     return element.toValue();
   },
 
+  dataStructureSerialiseContent: function(element) {
+    return [this.serialiseContent(element.content)];
+  },
+
   deserialise: function(value) {
     if (typeof value === 'string') {
       return new this.namespace.elements.String(value);

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -98,11 +98,16 @@ module.exports = createClass({
   },
 
   shouldRefract: function (element) {
-    if (element.element !== element.primitive() || element.element === 'member') {
+    if (element.attributes.keys().length || element.meta.keys().length) {
       return true;
     }
 
-    if (element.attributes.keys().length || element.meta.keys().length) {
+    if (element.element === 'enum') {
+      // enum elements are treated like primitives (array)
+      return false;
+    }
+
+    if (element.element !== element.primitive() || element.element === 'member') {
       return true;
     }
 
@@ -114,6 +119,10 @@ module.exports = createClass({
       return this.serialise(item);
     }
 
+    if (item.element === 'enum') {
+      return this.serialiseEnum(item);
+    }
+
     if (item.element === 'array') {
       // This is a plain array, but maybe it contains elements with
       // additional information? Let's see!
@@ -122,8 +131,15 @@ module.exports = createClass({
       for (var index = 0; index < item.length; index++) {
         var subItem = item.get(index);
 
-        if (this.shouldRefract(subItem)) {
+        if (this.shouldRefract(subItem) || key === 'default') {
           values.push(this.serialise(subItem));
+        } else if (subItem.element === 'array' || subItem.element === 'enum') {
+          // items for array or enum inside array are always serialised
+          var self = this;
+          var value = subItem.children.map(function(subSubItem) {
+            return self.serialise(subSubItem);
+          });
+          values.push(value);
         } else {
           values.push(subItem.toValue());
         }
@@ -139,6 +155,14 @@ module.exports = createClass({
     }
 
     return item.toValue();
+  },
+
+  serialiseEnum: function(element) {
+    var self = this;
+
+    return element.children.map(function(item) {
+      return self.serialise(item);
+    });
   },
 
   serialiseObject: function(obj) {

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -19,7 +19,16 @@ module.exports = createClass({
     }
 
     if (element.attributes.length > 0) {
-      payload['attributes'] = this.serialiseObject(element.attributes);
+      var attributes = element.attributes;
+
+      // Meta attribute was renamed to metadata
+      if (attributes.get('metadata')) {
+        attributes = attributes.clone();
+        attributes.set('meta', attributes.get('metadata'));
+        attributes.remove('metadata');
+      }
+
+      payload['attributes'] = this.serialiseObject(attributes);
     }
 
     if (this[element.element + 'SerialiseContent']) {

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -1,0 +1,159 @@
+'use strict';
+
+var createClass = require('uptown').createClass;
+var Namespace = require('../namespace');
+var KeyValuePair = require('../key-value-pair');
+
+module.exports = createClass({
+  constructor: function(namespace) {
+    this.namespace = namespace || new Namespace();
+  },
+
+  serialise: function(element) {
+    var payload = {
+      element: element.element,
+    };
+
+    if (element.meta.length > 0) {
+      payload['meta'] = this.serialiseObject(element.meta);
+    }
+
+    if (element.attributes.length > 0) {
+      payload['attributes'] = this.serialiseObject(element.attributes);
+    }
+
+    payload['content'] = this.serialiseContent(element.content);
+
+    return payload;
+  },
+
+  deserialise: function(value) {
+    if (typeof value === 'string') {
+      return new this.namespace.elements.String(value);
+    } else if (typeof value === 'number') {
+      return new this.namespace.elements.Number(value);
+    } else if (typeof value === 'boolean') {
+      return new this.namespace.elements.Boolean(value);
+    } else if (value === null) {
+      return new this.namespace.elements.Null();
+    } else if (value.map) {
+      return value.map(this.deserialise, this);
+    }
+
+    var ElementClass = this.namespace.getElementClass(value.element);
+    var element = new ElementClass();
+
+    if (element.element !== value.element) {
+      element.element = value.element;
+    }
+
+    if (value.meta) {
+      this.deserialiseObject(value.meta, element.meta);
+    }
+
+    if (value.attributes) {
+      this.deserialiseObject(value.attributes, element.attributes);
+    }
+
+    element.content = this.deserialiseContent(value.content);
+
+    return element;
+  },
+
+  // Private API
+
+  serialiseContent: function(content) {
+    if (content instanceof this.namespace.Element) {
+      return this.serialise(content);
+    } else if (content instanceof KeyValuePair) {
+      return {
+        'key': this.serialise(content.key),
+        'value': this.serialise(content.value)
+      };
+    } else if (content && content.map) {
+      return content.map(this.serialise, this);
+    }
+
+    return content;
+  },
+
+  deserialiseContent: function(content) {
+    if (content) {
+      if (content.element) {
+        return this.deserialise(content);
+      } else if (content.key) {
+        var pair = new KeyValuePair(this.deserialise(content.key));
+
+        if (content.value) {
+          pair.value = this.deserialise(content.value);
+        }
+
+        return pair;
+      } else if (content.map) {
+        return content.map(this.deserialise, this);
+      }
+    }
+
+    return content;
+  },
+
+  shouldRefract: function (element) {
+    if (element.element !== element.primitive() || element.element === 'member') {
+      return true;
+    }
+
+    if (element.attributes.keys().length || element.meta.keys().length) {
+      return true;
+    }
+
+    return false;
+  },
+
+  convertKeyToRefract: function (key, item) {
+    if (this.shouldRefract(item)) {
+      return this.serialise(item);
+    }
+
+    if (item.element === 'array') {
+      // This is a plain array, but maybe it contains elements with
+      // additional information? Let's see!
+      var values = [];
+
+      for (var index = 0; index < item.length; index++) {
+        var subItem = item.get(index);
+
+        if (this.shouldRefract(subItem)) {
+          values.push(this.serialise(subItem));
+        } else {
+          values.push(subItem.toValue());
+        }
+      }
+
+      return values;
+    }
+
+    if (item.element === 'object') {
+      // This is an object, so we need to check if it's members contain
+      // additional information
+      // TODO
+    }
+
+    return item.toValue();
+  },
+
+  serialiseObject: function(obj) {
+    var result = {};
+
+    obj.keys().forEach(function (key) {
+      result[key] = this.convertKeyToRefract(key, obj.get(key));
+    }, this);
+
+    return result;
+  },
+
+  deserialiseObject: function(from, to) {
+    Object.keys(from).forEach(function (key) {
+      to.set(key, this.deserialise(from[key]));
+    }, this);
+  }
+});

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -31,6 +31,15 @@ module.exports = createClass({
     return payload;
   },
 
+  refSerialiseContent: function(element, payload) {
+    delete payload['attributes'];
+
+    return {
+      href: element.toValue(),
+      path: element.path.toValue(),
+    };
+  },
+
   deserialise: function(value) {
     if (typeof value === 'string') {
       return new this.namespace.elements.String(value);

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -40,6 +40,10 @@ module.exports = createClass({
     };
   },
 
+  sourceMapSerialiseContent: function(element) {
+    return element.toValue();
+  },
+
   deserialise: function(value) {
     if (typeof value === 'string') {
       return new this.namespace.elements.String(value);

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -66,8 +66,8 @@ module.exports = createClass({
       return new this.namespace.elements.Boolean(value);
     } else if (value === null) {
       return new this.namespace.elements.Null();
-    } else if (value.map) {
-      return value.map(this.deserialise, this);
+    } else if (Array.isArray(value)) {
+      return new this.namespace.elements.Array(value.map(this.deserialise, this));
     }
 
     var ElementClass = this.namespace.getElementClass(value.element);

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -22,27 +22,14 @@ module.exports = createClass({
       payload['attributes'] = this.serialiseObject(element.attributes);
     }
 
-    if (element.element === 'sourceMap') {
-      payload['content'] = element.toValue();
-      return payload;
-    }
-
     payload['content'] = this.serialiseContent(element.content);
 
     return payload;
   },
 
   deserialise: function(value) {
-    if (typeof value === 'string') {
-      return new this.namespace.elements.String(value);
-    } else if (typeof value === 'number') {
-      return new this.namespace.elements.Number(value);
-    } else if (typeof value === 'boolean') {
-      return new this.namespace.elements.Boolean(value);
-    } else if (value === null) {
-      return new this.namespace.elements.Null();
-    } else if (value.map) {
-      return value.map(this.deserialise, this);
+    if (!value.element) {
+      throw new Error('Given value is not an object containing an element name');
     }
 
     var ElementClass = this.namespace.getElementClass(value.element);
@@ -102,55 +89,11 @@ module.exports = createClass({
     return content;
   },
 
-  shouldRefract: function (element) {
-    if (element.element !== element.primitive() || element.element === 'member') {
-      return true;
-    }
-
-    if (element.attributes.keys().length || element.meta.keys().length) {
-      return true;
-    }
-
-    return false;
-  },
-
-  convertKeyToRefract: function (key, item) {
-    if (this.shouldRefract(item)) {
-      return this.serialise(item);
-    }
-
-    if (item.element === 'array') {
-      // This is a plain array, but maybe it contains elements with
-      // additional information? Let's see!
-      var values = [];
-
-      for (var index = 0; index < item.length; index++) {
-        var subItem = item.get(index);
-
-        if (this.shouldRefract(subItem)) {
-          values.push(this.serialise(subItem));
-        } else {
-          values.push(subItem.toValue());
-        }
-      }
-
-      return values;
-    }
-
-    if (item.element === 'object') {
-      // This is an object, so we need to check if it's members contain
-      // additional information
-      // TODO
-    }
-
-    return item.toValue();
-  },
-
   serialiseObject: function(obj) {
     var result = {};
 
     obj.keys().forEach(function (key) {
-      result[key] = this.convertKeyToRefract(key, obj.get(key));
+      result[key] = this.serialise(obj.get(key));
     }, this);
 
     return result;

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -266,7 +266,15 @@ describe('ArrayElement', function() {
             {
               element: 'string',
               meta: {
-                'classes': ['test-class']
+                'classes': {
+                  element: 'array',
+                  content: [
+                    {
+                      element: 'string',
+                      content: 'test-class'
+                    },
+                  ],
+                },
               },
               content: 'baz'
             }, {
@@ -278,7 +286,10 @@ describe('ArrayElement', function() {
                 {
                   element: 'string',
                   meta: {
-                    id: 'nested-id'
+                    id: {
+                      element: 'string',
+                      content: 'nested-id',
+                    }
                   },
                   content: 'bar'
                 }, {

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -190,10 +190,27 @@ describe('Element', function() {
     var el = minim.fromRefract({
       element: 'string',
       meta: {
-        id: 'foobar',
-        classes: ['a'],
-        title: 'A Title',
-        description: 'A Description'
+        id: {
+          element: 'string',
+          content: 'foobar',
+        },
+        classes: {
+          element: 'array',
+          content: [
+            {
+              element: 'string',
+              content: 'a'
+            }
+          ],
+        },
+        title: {
+          element: 'string',
+          content: 'A Title',
+        },
+        description: {
+          element: 'string',
+          content: 'A Description',
+        }
       }
     });
 
@@ -207,8 +224,14 @@ describe('Element', function() {
     var el = minim.fromRefract({
       element: 'string',
       attributes: {
-        href: 'foobar',
-        relation: 'create'
+        href: {
+          element: 'string',
+          content: 'foobar',
+        },
+        relation: {
+          element: 'string',
+          content: 'create',
+        }
       }
     });
 
@@ -226,15 +249,24 @@ describe('Element', function() {
         el = minim.fromRefract({
           element: 'string',
           meta: {
-            links: [
-              {
-                element: 'link',
-                attributes: {
-                  relation: 'foo',
-                  href: '/bar'
+            links: {
+              element: 'array',
+              content: [
+                {
+                  element: 'link',
+                  attributes: {
+                    relation: {
+                      element: 'string',
+                      content: 'foo',
+                    },
+                    href: {
+                      element: 'string',
+                      content: '/bar',
+                    }
+                  }
                 }
-              }
-            ]
+              ]
+            }
           },
           content: 'foobar'
         })
@@ -274,15 +306,24 @@ describe('Element', function() {
             el = minim.fromRefract({
               element: 'string',
               meta: {
-                links: [
-                  {
-                    element: 'link',
-                    attributes: {
-                      relation: 'foo',
-                      href: '/bar'
+                links: {
+                  element: 'array',
+                  content: [
+                    {
+                      element: 'link',
+                      attributes: {
+                        relation: {
+                          element: 'string',
+                          content: 'foo',
+                        },
+                        href: {
+                          element: 'string',
+                          content: '/bar',
+                        }
+                      }
                     }
-                  }
-                ]
+                  ]
+                }
               },
               content: 'foobar'
             });

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -1,0 +1,331 @@
+var _ = require('lodash');
+var expect = require('../spec-helper').expect;
+var Namespace = require('../../lib/minim').Namespace;
+var minim = require('../../lib/minim').namespace();
+var KeyValuePair = require('../../lib/key-value-pair');
+var JSONSerialiser = require('../../lib/serialisers/json-0.6');
+
+describe('JSON Serialiser', function() {
+  var serialiser;
+
+  beforeEach(function () {
+    serialiser = new JSONSerialiser(minim);
+  });
+
+  describe('initialisation', function() {
+    it('uses given namespace', function() {
+      expect(serialiser.namespace).to.equal(minim);
+    });
+
+    it('creates a default namespace when no namespace is given', function() {
+      serialiser = new JSONSerialiser();
+      expect(serialiser.namespace).to.be.instanceof(Namespace);
+    });
+  });
+
+  describe('serialisation', function() {
+    it('serialises a primitive element', function() {
+      var element = new minim.elements.String('Hello')
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        content: 'Hello'
+      });
+    });
+
+    it('serialises an element containing element', function() {
+      var string = new minim.elements.String('Hello')
+      var element = new minim.Element(string);
+      element.element = 'custom';
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'custom',
+        content: {
+          element: 'string',
+          content: 'Hello'
+        }
+      });
+    });
+
+    it('serialises an element containing element array', function() {
+      var string = new minim.elements.String('Hello')
+      var element = new minim.elements.Array([string]);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'array',
+        content: [
+          {
+            element: 'string',
+            content: 'Hello'
+          }
+        ]
+      });
+    });
+
+    it('serialise an element with object content', function() {
+      var element = new minim.elements.Element({ message: 'hello' });
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'element',
+        content: {
+          message: 'hello'
+        }
+      });
+    });
+
+    it('serialises an element containing a pair', function() {
+      var name = new minim.elements.String('name')
+      var doe = new minim.elements.String('Doe')
+      var element = new minim.elements.Member(name, doe);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'member',
+        content: {
+          key: {
+            element: 'string',
+            content: 'name'
+          },
+          value: {
+            element: 'string',
+            content: 'Doe'
+          },
+        }
+      });
+    });
+
+    it('serialises an elements meta', function() {
+      var doe = new minim.elements.String('Doe')
+      doe.title = 'Name';
+
+      var object = serialiser.serialise(doe);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        meta: {
+          title: 'Name'
+        },
+        content: 'Doe'
+      });
+    });
+
+    it('serialises an elements attributes', function() {
+      var element = new minim.elements.String('Hello World')
+      element.attributes.set('thread', 123);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        attributes: {
+          thread: 123
+        },
+        content: 'Hello World'
+      });
+    });
+
+    it('serialises an element with custom element attributes', function() {
+      var element = new minim.elements.String('Hello World')
+      element.attributes.set('thread', new minim.Element(123));
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        attributes: {
+          thread: {
+            element: 'element',
+            content: 123
+          }
+        },
+        content: 'Hello World'
+      });
+    });
+  });
+
+  describe('deserialisation', function() {
+    it('deserialise from a JSON object', function() {
+      var element = serialiser.deserialise({
+        element: 'string',
+        content: 'Hello'
+      });
+
+      expect(element).to.be.instanceof(minim.elements.String);
+      expect(element.content).to.equal('Hello');
+    });
+
+    it('deserialise from a JSON object containing an sub-element', function() {
+      var element = serialiser.deserialise({
+        element: 'custom',
+        content: {
+          element: 'string',
+          content: 'Hello',
+        }
+      });
+
+      expect(element).to.be.instanceof(minim.Element);
+      expect(element.content).to.be.instanceof(minim.elements.String);
+      expect(element.content.content).to.equal('Hello');
+    });
+
+    it('deserialise from a JSON object containing an array of elements', function() {
+      var element = serialiser.deserialise({
+        element: 'array',
+        content: [
+          {
+            element: 'string',
+            content: 'Hello',
+          }
+        ]
+      });
+
+      expect(element).to.be.instanceof(minim.elements.Array);
+      expect(element.content[0]).to.be.instanceof(minim.elements.String);
+      expect(element.content[0].content).to.equal('Hello');
+    });
+
+    it('deserialises from a JSON object containing JSON object content', function() {
+      var element = serialiser.deserialise({
+        element: 'element',
+        content: {
+          message: 'hello'
+        }
+      });
+
+      expect(element).to.be.instanceof(minim.elements.Element);
+      expect(element.content).to.deep.equal({ message: 'hello' });
+    });
+
+    it('deserialise from a JSON object containing a key-value pair', function() {
+      var element = serialiser.deserialise({
+        element: 'member',
+        content: {
+          key: {
+            element: 'string',
+            content: 'name',
+          },
+          value: {
+            element: 'string',
+            content: 'Doe'
+          }
+        }
+      });
+
+      expect(element).to.be.instanceof(minim.elements.Member);
+      expect(element.content).to.be.instanceof(KeyValuePair);
+      expect(element.key).to.be.instanceof(minim.elements.String);
+      expect(element.key.content).to.equal('name');
+      expect(element.value).to.be.instanceof(minim.elements.String);
+      expect(element.value.content).to.equal('Doe');
+    });
+
+    it('deserialise from a JSON object containing a key-value pair without value', function() {
+      var element = serialiser.deserialise({
+        element: 'member',
+        content: {
+          key: {
+            element: 'string',
+            content: 'name',
+          }
+        }
+      });
+
+      expect(element).to.be.instanceof(minim.elements.Member);
+      expect(element.content).to.be.instanceof(KeyValuePair);
+      expect(element.key).to.be.instanceof(minim.elements.String);
+      expect(element.key.content).to.equal('name');
+      expect(element.value).to.be.undefined;
+    });
+
+    it('deserialise meta', function() {
+      var element = serialiser.deserialise({
+        element: 'string',
+        meta: {
+          title: 'hello'
+        }
+      });
+
+      expect(element.title).to.be.instanceof(minim.elements.String);
+      expect(element.title.content).to.equal('hello');
+    });
+
+    it('deserialise refracted meta', function() {
+      var element = serialiser.deserialise({
+        element: 'string',
+        meta: {
+          title: {
+            element: 'string',
+            content: 'hello'
+          }
+        }
+      });
+
+      expect(element.title).to.be.instanceof(minim.elements.String);
+      expect(element.title.content).to.equal('hello');
+    });
+
+
+    it('deserialise attributes', function() {
+      var element = serialiser.deserialise({
+        element: 'string',
+        attributes: {
+          thing: 'hello'
+        }
+      });
+
+      const attribute = element.attributes.get('thing');
+      expect(attribute).to.be.instanceof(minim.elements.String);
+      expect(attribute.content).to.equal('hello');
+    });
+
+    it('deserialise refracted attributes', function() {
+      var element = serialiser.deserialise({
+        element: 'string',
+        attributes: {
+          thing: {
+            element: 'string',
+            content: 'hello'
+          }
+        }
+      });
+
+      const attribute = element.attributes.get('thing');
+      expect(attribute).to.be.instanceof(minim.elements.String);
+      expect(attribute.content).to.equal('hello');
+    });
+
+    it('deserialise string', function() {
+      var element = serialiser.deserialise('Hello');
+
+      expect(element).to.be.instanceof(minim.elements.String);
+      expect(element.content).to.equal('Hello');
+    });
+
+    it('deserialise number', function() {
+      var element = serialiser.deserialise(15);
+
+      expect(element).to.be.instanceof(minim.elements.Number);
+      expect(element.content).to.equal(15);
+    });
+
+    it('deserialise boolean', function() {
+      var element = serialiser.deserialise(true);
+
+      expect(element).to.be.instanceof(minim.elements.Boolean);
+      expect(element.content).to.equal(true);
+    });
+
+    it('deserialise null', function() {
+      var element = serialiser.deserialise(null);
+
+      expect(element).to.be.instanceof(minim.elements.Null);
+    });
+  });
+});

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -148,6 +148,74 @@ describe('JSON Serialiser', function() {
         content: 'Hello World'
       });
     });
+
+    it('serialises enum inside attributes as array', function() {
+      var element = new minim.elements.String('Hello World');
+      var enumeration = new minim.Element([new minim.elements.String('North')]);
+      var array = new minim.elements.Array([enumeration]);
+      enumeration.element = 'enum';
+      element.attributes.set('samples', array);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        attributes: {
+          samples: [
+            [
+              {
+                'element': 'string',
+                'content': 'North'
+              }
+            ]
+          ]
+        },
+        content: 'Hello World'
+      });
+    });
+
+    it('serialises enum inside array inside attributes as array', function() {
+      var element = new minim.elements.String('Hello World')
+      var enumeration = new minim.Element([new minim.elements.String('North')]);
+      enumeration.element = 'enum';
+      element.attributes.set('directions', enumeration);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        attributes: {
+          directions: [
+            {
+              'element': 'string',
+              'content': 'North'
+            }
+          ]
+        },
+        content: 'Hello World'
+      });
+    });
+
+    it('always serialises items inside `default` attribute array', function() {
+      var element = new minim.elements.String('Hello World')
+      var values = new minim.elements.Array([new minim.elements.String('North')]);
+      element.attributes.set('default', values);
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'string',
+        attributes: {
+          default: [
+            {
+              'element': 'string',
+              'content': 'North'
+            }
+          ]
+        },
+        content: 'Hello World'
+      });
+    });
   });
 
   describe('deserialisation', function() {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -216,6 +216,20 @@ describe('JSON Serialiser', function() {
         content: 'Hello World'
       });
     });
+
+    it('serialises a ref element', function() {
+      var element = new minim.elements.Ref('content');
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'ref',
+        content: {
+          path: 'element',
+          href: 'content',
+        }
+      });
+    });
   });
 
   describe('deserialisation', function() {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -459,5 +459,12 @@ describe('JSON Serialiser', function() {
 
       expect(element).to.be.instanceof(minim.elements.Null);
     });
+
+    it('deserialises an array element from JS array', function() {
+      var element = serialiser.deserialise([1]);
+
+      expect(element).to.be.instanceof(minim.elements.Array);
+      expect(element.get(0)).to.be.instanceof(minim.elements.Number);
+    });
   });
 });

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -230,6 +230,22 @@ describe('JSON Serialiser', function() {
         }
       });
     });
+
+    it('serialises a sourceMap element as values', function() {
+      var element = new minim.elements.Element(
+        new minim.elements.Array(
+          [new minim.elements.Array([1,2])]
+        )
+      );
+      element.element = 'sourceMap';
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'sourceMap',
+        content: [[1,2]]
+      });
+    });
   });
 
   describe('deserialisation', function() {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -246,6 +246,25 @@ describe('JSON Serialiser', function() {
         content: [[1,2]]
       });
     });
+
+    it('serialises a dataStructure element inside an array', function() {
+      var element = new minim.elements.Element(
+        new minim.elements.String('Hello')
+      );
+      element.element = 'dataStructure';
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'dataStructure',
+        content: [
+          {
+            element: 'string',
+            content: 'Hello'
+          }
+        ]
+      });
+    });
   });
 
   describe('deserialisation', function() {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -265,6 +265,21 @@ describe('JSON Serialiser', function() {
         ]
       });
     });
+
+    it('serialises a element attribute called meta as metadata', function() {
+      var element = new minim.elements.Null();
+      element.attributes.set('metadata', 'example');
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'null',
+        attributes: {
+          meta: 'example'
+        },
+        content: null
+      });
+    });
   });
 
   describe('deserialisation', function() {

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -110,7 +110,10 @@ describe('JSON Serialiser', function() {
       expect(object).to.deep.equal({
         element: 'string',
         meta: {
-          title: 'Name'
+          title: {
+            element: 'string',
+            content: 'Name',
+          }
         },
         content: 'Doe'
       });
@@ -125,7 +128,10 @@ describe('JSON Serialiser', function() {
       expect(object).to.deep.equal({
         element: 'string',
         attributes: {
-          thread: 123
+          thread: {
+            element: 'number',
+            content: 123
+          },
         },
         content: 'Hello World'
       });
@@ -148,25 +154,13 @@ describe('JSON Serialiser', function() {
         content: 'Hello World'
       });
     });
-
-    it('serialises a sourceMap element as values', function() {
-      var element = new minim.elements.Element(
-        new minim.elements.Array(
-          [new minim.elements.Array([1,2])]
-        )
-      );
-      element.element = 'sourceMap';
-
-      var object = serialiser.serialise(element);
-
-      expect(object).to.deep.equal({
-        element: 'sourceMap',
-        content: [[1,2]]
-      });
-    });
   });
 
   describe('deserialisation', function() {
+    it('errors when deserialising value without element name', function() {
+      expect(function() { return serialiser.deserialise({}); }).to.throw();
+    });
+
     it('deserialise from a JSON object', function() {
       var element = serialiser.deserialise({
         element: 'string',
@@ -205,18 +199,6 @@ describe('JSON Serialiser', function() {
       expect(element).to.be.instanceof(minim.elements.Array);
       expect(element.content[0]).to.be.instanceof(minim.elements.String);
       expect(element.content[0].content).to.equal('Hello');
-    });
-
-    it('deserialises from a JSON object containing JSON object content', function() {
-      var element = serialiser.deserialise({
-        element: 'element',
-        content: {
-          message: 'hello'
-        }
-      });
-
-      expect(element).to.be.instanceof(minim.elements.Element);
-      expect(element.content).to.deep.equal({ message: 'hello' });
     });
 
     it('deserialise from a JSON object containing a key-value pair', function() {
@@ -264,21 +246,9 @@ describe('JSON Serialiser', function() {
       var element = serialiser.deserialise({
         element: 'string',
         meta: {
-          title: 'hello'
-        }
-      });
-
-      expect(element.title).to.be.instanceof(minim.elements.String);
-      expect(element.title.content).to.equal('hello');
-    });
-
-    it('deserialise refracted meta', function() {
-      var element = serialiser.deserialise({
-        element: 'string',
-        meta: {
           title: {
             element: 'string',
-            content: 'hello'
+            content: 'hello',
           }
         }
       });
@@ -287,21 +257,7 @@ describe('JSON Serialiser', function() {
       expect(element.title.content).to.equal('hello');
     });
 
-
     it('deserialise attributes', function() {
-      var element = serialiser.deserialise({
-        element: 'string',
-        attributes: {
-          thing: 'hello'
-        }
-      });
-
-      const attribute = element.attributes.get('thing');
-      expect(attribute).to.be.instanceof(minim.elements.String);
-      expect(attribute.content).to.equal('hello');
-    });
-
-    it('deserialise refracted attributes', function() {
       var element = serialiser.deserialise({
         element: 'string',
         attributes: {
@@ -318,28 +274,39 @@ describe('JSON Serialiser', function() {
     });
 
     it('deserialise string', function() {
-      var element = serialiser.deserialise('Hello');
+      var element = serialiser.deserialise({
+        element: 'string',
+        content: 'Hello',
+      });
 
       expect(element).to.be.instanceof(minim.elements.String);
       expect(element.content).to.equal('Hello');
     });
 
     it('deserialise number', function() {
-      var element = serialiser.deserialise(15);
+      var element = serialiser.deserialise({
+        element: 'number',
+        content: 15,
+      });
 
       expect(element).to.be.instanceof(minim.elements.Number);
       expect(element.content).to.equal(15);
     });
 
     it('deserialise boolean', function() {
-      var element = serialiser.deserialise(true);
+      var element = serialiser.deserialise({
+        element: 'boolean',
+        content: true
+      });
 
       expect(element).to.be.instanceof(minim.elements.Boolean);
       expect(element.content).to.equal(true);
     });
 
     it('deserialise null', function() {
-      var element = serialiser.deserialise(null);
+      var element = serialiser.deserialise({
+        element: 'null',
+      });
 
       expect(element).to.be.instanceof(minim.elements.Null);
     });

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -45,19 +45,28 @@ describe('Minim subclasses', function() {
             {
               element: 'string',
               meta: {
-                name: 'Content-Type'
+                name: {
+                  element: 'string',
+                  content: 'Content-Type',
+                }
               },
               content: 'application/json'
             }
           ]
         },
-        foo: 'bar',
-        sourceMap: [
-          {
-            element: 'string',
-            content: 'test'
-          }
-        ]
+        foo: {
+          element: 'string',
+          content: 'bar',
+        },
+        sourceMap: {
+          element: 'sourceMap',
+          content: [
+            {
+              element: 'string',
+              content: 'test'
+            }
+          ]
+        }
       }
     });
 
@@ -71,9 +80,9 @@ describe('Minim subclasses', function() {
 
     it('should create array of source map elements', function() {
       var sourceMaps = myElement.attributes.get('sourceMap');
-      expect(sourceMaps).to.have.length(1);
-      expect(sourceMaps.first()).to.be.instanceOf(StringElement);
-      expect(sourceMaps.first().toValue()).to.equal('test');
+      expect(sourceMaps.content).to.have.length(1);
+      expect(sourceMaps.content[0]).to.be.instanceOf(StringElement);
+      expect(sourceMaps.content[0].toValue()).to.equal('test');
     });
   });
 
@@ -91,19 +100,34 @@ describe('Minim subclasses', function() {
       expect(refracted).to.deep.equal({
         element: 'myElement',
         attributes: {
-          headers: [
-            {
-              element: 'string',
-              meta: {
-                name: 'Content-Type'
+          headers: {
+            element: 'array',
+            content: [
+              {
+                element: 'string',
+                meta: {
+                  name: {
+                    element: 'string',
+                    content: 'Content-Type',
+                  },
+                },
+                content: 'application/json'
               },
-              content: 'application/json'
-            }
-          ],
-          sourceMap: [
-            'string1',
-            'string2'
-          ]
+            ],
+          },
+          sourceMap: {
+            element: 'array',
+            content: [
+              {
+                element: 'string',
+                content: 'string1',
+              },
+              {
+                element: 'string',
+                content: 'string2',
+              },
+            ],
+          },
         },
         content: null
       });


### PR DESCRIPTION
This pull request updates the JSON Serialiser to follow Refract 1.0 JSON Serialisation rules. This PR also includes commits that provide the old serialiser and old serialisation rules for API Elements. As you can see in the changes there was a lot of custom serialisation based on the element (`sourceMap`, `enum`) and even rules based on attribute key names (`default`) that differ from other attributes. 

- d2c74a1 - Updates to follow new serialisation rules
- 066aad1a939faec8833426054d26bb1f1ad6ce9f - Moves the old serialiser and old serialiser tests to the json-0.6 file. This commit does not change any of the existing code so the contents (other than file creation) do not need to be reviewed. Changes are done separately in follow up commits.
- https://github.com/refractproject/minim/pull/127/commits/cc0995a885946962af7eee14502fae412253ce61 - This commit changes the serialiser to be consistent with the attribute/meta serialisation rules that Drafter used.
- https://github.com/refractproject/minim/pull/127/commits/69db54dbd704e8358249cf4d78881bbf6acd64f7 is minor refactoring allowing the serialiser to contain a method to override the content serialiser for a given element type. This is used in the subsequent commits.
- https://github.com/refractproject/minim/pull/127/commits/13a29ad5ac446ce2f60021741df641fccd8d5dbc - Encode ref elements like Refract 0.6.
- e305796 - Wrap dataStructure content in arrays like Drafter v3
- https://github.com/refractproject/minim/pull/127/commits/1c7ec1827156f23f0bd580ec907d0318c22b5bba - Serialise metadata attributes as meta.

### Tasks

- [x] Test in Swagger - https://github.com/apiaryio/swagger-zoo/pull/39 updates the Swagger fixtures to use the new serialiser.
- [x] Test re-serialisation from new/old serialiser using Drafter fixtures.

Using the following script, we can take all of the test fixtures from Drafter and then re-serialise the elements using JSON 0.6 serialiser and compare to fixtures found in Drafter 3.x. This allows us to be sure that re-serialisation works exactly as the old serialised responses from Drafter.

```js
var fs = require('fs');
var glob = require('glob');
var differ = require('json-diff'); // https://github.com/andreyvit/json-diff
var minim = require('./lib/minim').namespace();
var JSON06Serialiser = require('./lib/serialisers/json-0.6');

var serialiser = new JSON06Serialiser();

var drafter3 = '/Users/kyle/Projects/apiary/drafter3'; // v3.2.7 source
var drafter4 = '/Users/kyle/Projects/apiary/drafter'; // master source

var ignored = [
  // https://github.com/apiaryio/drafter/pull/484
  '/test/fixtures/schema/array-restricted-to-type.json',
  '/test/fixtures/schema/array-restricted-to-types-complex.json',
  '/test/fixtures/schema/array-restricted-to-types.json',

  // https://github.com/apiaryio/drafter/pull/483
  '/test/fixtures/api/schema-custom-json.json',

  // drafter 3.x was incorrectly adding empty api category during error case
  '/test/fixtures/parse-result/error.json',
];

var fixtures = glob
  .sync(drafter4 + '/test/**/*.json')
  .map(path => path.replace(drafter4, ''))
  .filter(path => !ignored.includes(path));

var success = 0;
var failed = 0;
var skipped = 0;

for (var fixture of fixtures) {
  try {
    var oldFixture = require(drafter3 + fixture);
    var newFixture = require(drafter4 + fixture);
  } catch (error) {
    // Fixture is doesn't exist in old version (probably was ast named .ast.json)
    skipped++;
    continue;
  }

  if (oldFixture['_version']) {
    // Fixture is AST
    skipped++;
    continue;
  }

  // Deserialise the new fixture
  const element = minim.fromRefract(newFixture);

  // Re-serialise element as Refract 0.6
  const reserailised = serialiser.serialise(element);

  // Compare re-serialised against old fixture
  const oldFixtureJSON = JSON.stringify(oldFixture, null, 2);
  const reserialisedJSON = JSON.stringify(reserailised, null, 2)

  if (oldFixtureJSON !== reserialisedJSON) {
    const diff = differ.diffString(reserailised, oldFixture);
    process.stdout.write(diff);
    failed++;
  } else {
    success++;
  }
}

console.log(`${success} success, ${failed} failed and ${skipped} skipped.`);
```