### PR TITLE
Align high-order functions to accept thisArg and to use same signatures as Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- ArrayElement high-order functions, `map`, `filter` and `forEach` now accept
+  `thisArg` like the equivalent functionality in `Array`.
+
 # 0.17.1 - 2016-07-29
 
 ## Bug Fixes

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -54,13 +54,13 @@ var ArrayElement = Element.extend({
     return null;
   },
 
-  map: function(cb) {
-    return this.content.map(cb);
+  map: function(callback, thisArg) {
+    return this.content.map(callback, thisArg);
   },
 
-  filter: function(condition) {
+  filter: function(callback, thisArg) {
     var newArray = new ArrayElement();
-    newArray.content = this.content.filter(condition);
+    newArray.content = this.content.filter(callback, thisArg);
     return newArray;
   },
 
@@ -69,14 +69,14 @@ var ArrayElement = Element.extend({
    * allows for returning normal values or Minim instances, so it converts any
    * primitives on each step.
    */
-  reduce: function(fn, givenMemo) {
+  reduce: function(callback, initialValue) {
     var startIndex;
     var memo;
 
     // Allows for defining a starting value of the reduce
-    if (!_.isUndefined(givenMemo)) {
+    if (!_.isUndefined(initialValue)) {
       startIndex = 0;
-      memo = refract(givenMemo);
+      memo = refract(initialValue);
     } else {
       startIndex = 1;
       // Object Element content items are member elements. Because of this,
@@ -92,19 +92,19 @@ var ArrayElement = Element.extend({
       var item = this.content[i];
 
       if (this.primitive() === 'object') {
-        memo = refract(fn(memo, item.value, item.key, item, this));
+        memo = refract(callback(memo, item.value, item.key, item, this));
       } else {
-        memo = refract(fn(memo, item, i, this));
+        memo = refract(callback(memo, item, i, this));
       }
     }
 
     return memo;
   },
 
-  forEach: function(cb) {
+  forEach: function(callback, thisArg) {
     this.content.forEach(function(item, index) {
-      cb(item, refract(index));
-    });
+      callback(item, refract(index));
+    }, thisArg);
   },
 
   shift: function() {


### PR DESCRIPTION
Align high-order functions to accept thisArg and to use same signatures as Array.

- map: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
- filter: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
- forEach: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
- reduce: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce