### PR TITLE
Make find* methods on ArrayElement return an element slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Master
 
-- `Element.children` now returns `ElementSlice` instead of an `ArrayElement`.
-- `Element.recursiveChildren` now returns `ElementSlice` instead of an `ArrayElement`.
-- `ArrayElement.filter` now returns `ElementSlice` instead of an
-  `ArrayElement`.
-- `Element.findRecursive` now returns `ElementSlice` instead of an
-  `ArrayElement`.
+- `Element.children` and `Element.recursiveChildren` now return `ElementSlice`
+  instead of an `ArrayElement`.
+- `ArrayElement.filter` and `ArrayElement.find*` now return `ElementSlice`
+  instead of an `ArrayElement`.
 - The `first`, `second` and `last` methods on `ArrayElement` are now properties
   instead of methods.
 

--- a/lib/element-slice.js
+++ b/lib/element-slice.js
@@ -93,7 +93,13 @@ var ElementSlice = createClass({
     get: function() {
       return this.elements.length === 0;
     }
-  }
+  },
+
+  first: {
+    get: function() {
+      return this.elements[0];
+    }
+  },
 });
 
 if (typeof Symbol !== 'undefined') {

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -152,9 +152,7 @@ var ArrayElement = Element.extend({
    * Recusively search all descendents using a condition function.
    */
   find: function(condition) {
-    var newArray = new ArrayElement();
-    newArray.content = this.findElements(condition, {recursive: true});
-    return newArray;
+    return new ElementSlice(this.findElements(condition, {recursive: true}));
   },
 
   findByElement: function(element) {

--- a/test/element-slice-test.js
+++ b/test/element-slice-test.js
@@ -142,4 +142,19 @@ describe('ElementSlice', function () {
     var slice = new ElementSlice([one]);
     expect(slice.getValue(0)).to.equal('one');
   });
+
+  describe('#first', function () {
+    it('returns the first item', function () {
+      var element = new Element();
+      var slice = new ElementSlice([element]);
+
+      expect(slice.first).to.equal(element);
+    });
+
+    it('returns undefined when there isnt any items', function () {
+      var slice = new ElementSlice();
+
+      expect(slice.first).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
These methods was missed in #132. I've also added a `first` convince property on ElementSlice. I've renamed arrays methods to be consistent in https://github.com/refractproject/minim/pull/134.