### PR TITLE
Create ObjectSlice for object related slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   instead of an `ArrayElement`.
 - The `first`, `second` and `last` methods on `ArrayElement` are now properties
   instead of methods.
+- `ObjectElement.filter` now returns an `ObjectSlice` instead of an
+  `ObjectElement`.
 
 # 0.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Master
 
-- `Element.children` and `Element.recursiveChildren` now return `ElementSlice`
+- `Element.children` and `Element.recursiveChildren` now return `ArraySlice`
   instead of an `ArrayElement`.
-- `ArrayElement.filter` and `ArrayElement.find*` now return `ElementSlice`
+- `ArrayElement.filter` and `ArrayElement.find*` now return `ArraySlice`
   instead of an `ArrayElement`.
 - The `first`, `second` and `last` methods on `ArrayElement` are now properties
   instead of methods.

--- a/lib/array-slice.js
+++ b/lib/array-slice.js
@@ -5,7 +5,7 @@ var uptown = require('uptown');
 var refract = require('./refraction').refract;
 var createClass = uptown.createClass;
 
-var ElementSlice = createClass({
+var ArraySlice = createClass({
   // elements: [Element]
   constructor: function (elements) {
     this.elements = elements || [];
@@ -26,7 +26,7 @@ var ElementSlice = createClass({
   // Filters the element slice
   // Returns a new sub slice
   filter: function (callback, thisArg) {
-    return new ElementSlice(this.elements.filter(callback, thisArg));
+    return new ArraySlice(this.elements.filter(callback, thisArg));
   },
 
   forEach: function (callback, thisArg) {
@@ -103,9 +103,9 @@ var ElementSlice = createClass({
 });
 
 if (typeof Symbol !== 'undefined') {
-  ElementSlice.prototype[Symbol.iterator] = function () {
+  ArraySlice.prototype[Symbol.iterator] = function () {
     return this.elements[Symbol.iterator]();
   };
 }
 
-module.exports = ElementSlice;
+module.exports = ArraySlice;

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -21,5 +21,5 @@ exports.ObjectElement = require('./primitives/object-element');
 exports.MemberElement = require('./primitives/member-element');
 exports.RefElement = require('./elements/ref-element');
 exports.LinkElement = require('./elements/link-element');
-exports.ElementSlice = require('./element-slice');
+exports.ArraySlice = require('./array-slice');
 exports.ObjectSlice = require('./object-slice');

--- a/lib/minim.js
+++ b/lib/minim.js
@@ -22,3 +22,4 @@ exports.MemberElement = require('./primitives/member-element');
 exports.RefElement = require('./elements/ref-element');
 exports.LinkElement = require('./elements/link-element');
 exports.ElementSlice = require('./element-slice');
+exports.ObjectSlice = require('./object-slice');

--- a/lib/object-slice.js
+++ b/lib/object-slice.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var _ = require('lodash');
-var ElementSlice = require('./element-slice');
+var ArraySlice = require('./array-slice');
 
-var ObjectSlice = ElementSlice.extend({
+var ObjectSlice = ArraySlice.extend({
   map: function(callback, thisArg) {
     return this.elements.map(function(member) {
       return callback(member.value, member.key, member);

--- a/lib/object-slice.js
+++ b/lib/object-slice.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var _ = require('lodash');
+var ElementSlice = require('./element-slice');
+
+var ObjectSlice = ElementSlice.extend({
+  map: function(callback, thisArg) {
+    return this.elements.map(function(member) {
+      return callback(member.value, member.key, member);
+    }, thisArg);
+  },
+
+  filter: function(callback, thisArg) {
+    return new ObjectSlice(this.elements.filter(function(member) {
+      return callback(member.value, member.key, member);
+    }, thisArg));
+  },
+
+  forEach: function(callback, thisArg) {
+    return this.elements.forEach(function(member, index) {
+      return callback(member.value, member.key, member, index);
+    }, thisArg);
+  },
+
+  keys: function() {
+    return this.map(function(value, key) {
+      return key.toValue();
+    });
+  },
+
+  values: function() {
+    return this.map(function(value) {
+      return value.toValue();
+    });
+  },
+});
+
+module.exports = ObjectSlice;

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -3,7 +3,7 @@
 var _ = require('lodash');
 var refract = require('../refraction').refract;
 var Element = require('./element');
-var ElementSlice = require('../element-slice');
+var ArraySlice = require('../array-slice');
 
 var ArrayElement = Element.extend({
   constructor: function (content, meta, attributes) {
@@ -60,7 +60,7 @@ var ArrayElement = Element.extend({
   },
 
   filter: function(callback, thisArg) {
-    return new ElementSlice(this.content.filter(callback, thisArg));
+    return new ArraySlice(this.content.filter(callback, thisArg));
   },
 
   /*
@@ -152,7 +152,7 @@ var ArrayElement = Element.extend({
    * Recusively search all descendents using a condition function.
    */
   find: function(condition) {
-    return new ElementSlice(this.findElements(condition, {recursive: true}));
+    return new ArraySlice(this.findElements(condition, {recursive: true}));
   },
 
   findByElement: function(element) {

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var uptown = require('uptown');
 var createClass = uptown.createClass;
 var KeyValuePair = require('../key-value-pair');
-var ElementSlice = require('../element-slice.js');
+var ArraySlice = require('../array-slice.js');
 
 var Element = createClass({
   constructor: function(content, meta, attributes) {
@@ -95,19 +95,19 @@ var Element = createClass({
   },
 
   /// Finds the given elements in the element tree
-  /// Returns ElementSlice of elements
+  /// Returns ArraySlice of elements
   /// findRecursive: function(names..., parents)
   findRecursive: function() {
     var ArrayElement = require('./array-element');
     var elementNames = [].concat.apply([], arguments);
-    var elements = new ElementSlice();
+    var elements = new ArraySlice();
     var parents;
 
-    if (elementNames[elementNames.length - 1] instanceof ElementSlice) {
+    if (elementNames[elementNames.length - 1] instanceof ArraySlice) {
       // clone the given parents
-      parents = new ElementSlice(elementNames.pop().map(function (e) { return e; }));
+      parents = new ArraySlice(elementNames.pop().map(function (e) { return e; }));
     } else {
-      parents = new ElementSlice();
+      parents = new ArraySlice();
     }
 
     var elementName = elementNames.pop();
@@ -310,9 +310,9 @@ var Element = createClass({
       var ArrayElement = require('./array-element');
 
       if (Array.isArray(this.content)) {
-        return new ElementSlice(this.content);
+        return new ArraySlice(this.content);
       } else if (this.content instanceof KeyValuePair) {
-        var children = new ElementSlice([this.content.key]);
+        var children = new ArraySlice([this.content.key]);
 
         if (this.content.value) {
           children.push(this.content.value);
@@ -320,16 +320,16 @@ var Element = createClass({
 
         return children;
       } else if (this.content instanceof Element) {
-        return new ElementSlice([this.content]);
+        return new ArraySlice([this.content]);
       } else {
-        return new ElementSlice();
+        return new ArraySlice();
       }
     }
   },
 
   recursiveChildren: {
     get: function() {
-      var children = new ElementSlice();
+      var children = new ArraySlice();
 
       this.children.forEach(function (element) {
         children.push(element);

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -5,6 +5,7 @@ var _ = require('lodash');
 var Element = require('./element');
 var ArrayElement = require('./array-element');
 var MemberElement = require('./member-element');
+var ObjectSlice = require('../object-slice');
 
 var ObjectElement = ArrayElement.extend({
   constructor: function (content, meta, attributes) {
@@ -134,13 +135,8 @@ var ObjectElement = ArrayElement.extend({
     });
   },
 
-  filter: function(cb) {
-    // Create a new object with new member elements
-    var obj = new ObjectElement([], this.meta, this.attributes);
-    obj.content = this.content.filter(function(item) {
-      return cb(item.value, item.key, item);
-    });
-    return obj;
+  filter: function(callback, thisArg) {
+    return new ObjectSlice(this.content).filter(callback, thisArg);
   },
 
   forEach: function(cb) {

--- a/test/array-slice-test.js
+++ b/test/array-slice-test.js
@@ -1,42 +1,42 @@
 var expect = require('./spec-helper').expect;
 var minim = require('../lib/minim');
 var Element = minim.Element;
-var ElementSlice = minim.ElementSlice;
+var ArraySlice = minim.ArraySlice;
 
-describe('ElementSlice', function () {
+describe('ArraySlice', function () {
   it('can be created from an array of elements', function () {
     var element = new Element();
-    var slice = new ElementSlice([element]);
+    var slice = new ArraySlice([element]);
 
     expect(slice.elements).to.deep.equal([element]);
   });
 
   it('returns the length of the slice', function () {
-    var slice = new ElementSlice([new Element()]);
+    var slice = new ArraySlice([new Element()]);
 
     expect(slice.length).to.equal(1);
   });
 
   it('returns when the slice is empty', function () {
-    var slice = new ElementSlice();
+    var slice = new ArraySlice();
     expect(slice.isEmpty).to.be.true;
   });
 
   it('returns when the slice is not empty', function () {
-    var slice = new ElementSlice([new ElementSlice()]);
+    var slice = new ArraySlice([new ArraySlice()]);
     expect(slice.isEmpty).to.be.false;
   });
 
   it('allows converting to value', function () {
     var element = new Element('hello');
-    var slice = new ElementSlice([element]);
+    var slice = new ArraySlice([element]);
 
     expect(slice.toValue()).to.deep.equal(['hello']);
   });
 
   it('provides map', function () {
     var element = new Element('hello');
-    var slice = new ElementSlice([element]);
+    var slice = new ArraySlice([element]);
 
     var mapped = slice.map(function (element) {
       return element.toValue();
@@ -48,20 +48,20 @@ describe('ElementSlice', function () {
   it('provides filter', function () {
     var one = new Element('one');
     var two = new Element('two');
-    var slice = new ElementSlice([one, two]);
+    var slice = new ArraySlice([one, two]);
 
     var filtered = slice.filter(function (element) {
       return element.toValue() === 'one';
     });
 
-    expect(filtered).to.be.instanceof(ElementSlice);
+    expect(filtered).to.be.instanceof(ArraySlice);
     expect(filtered.elements).to.deep.equal([one]);
   });
 
   it('provides forEach', function () {
     var one = new Element('one');
     var two = new Element('two');
-    var slice = new ElementSlice([one, two]);
+    var slice = new ArraySlice([one, two]);
 
     var elements = [];
     var indexes = [];
@@ -76,7 +76,7 @@ describe('ElementSlice', function () {
   });
 
   describe('#includes', function () {
-    var slice = new ElementSlice([
+    var slice = new ArraySlice([
       new Element('one'),
       new Element('two'),
     ]);
@@ -93,7 +93,7 @@ describe('ElementSlice', function () {
   it('allows shifting an element', function () {
     var one = new Element('one');
     var two = new Element('two');
-    var slice = new ElementSlice([one, two]);
+    var slice = new ArraySlice([one, two]);
 
     var shifted = slice.shift();
 
@@ -103,7 +103,7 @@ describe('ElementSlice', function () {
 
   it('allows unshifting an element', function () {
     var two = new Element('two');
-    var slice = new ElementSlice([two]);
+    var slice = new ArraySlice([two]);
 
     slice.unshift('one');
 
@@ -113,7 +113,7 @@ describe('ElementSlice', function () {
 
   it('allows pushing new items to end', function () {
     var one = new Element('one');
-    var slice = new ElementSlice([one]);
+    var slice = new ArraySlice([one]);
 
     slice.push('two');
 
@@ -123,7 +123,7 @@ describe('ElementSlice', function () {
 
   it('allows adding new items to end', function () {
     var one = new Element('one');
-    var slice = new ElementSlice([one]);
+    var slice = new ArraySlice([one]);
 
     slice.add('two');
 
@@ -133,26 +133,26 @@ describe('ElementSlice', function () {
 
   it('allows getting an element via index', function () {
     var one = new Element('one');
-    var slice = new ElementSlice([one]);
+    var slice = new ArraySlice([one]);
     expect(slice.get(0)).to.deep.equal(one);
   });
 
   it('allows getting a value via index', function () {
     var one = new Element('one');
-    var slice = new ElementSlice([one]);
+    var slice = new ArraySlice([one]);
     expect(slice.getValue(0)).to.equal('one');
   });
 
   describe('#first', function () {
     it('returns the first item', function () {
       var element = new Element();
-      var slice = new ElementSlice([element]);
+      var slice = new ArraySlice([element]);
 
       expect(slice.first).to.equal(element);
     });
 
     it('returns undefined when there isnt any items', function () {
-      var slice = new ElementSlice();
+      var slice = new ArraySlice();
 
       expect(slice.first).to.be.undefined;
     });

--- a/test/object-slice-test.js
+++ b/test/object-slice-test.js
@@ -1,0 +1,68 @@
+var expect = require('./spec-helper').expect;
+var minim = require('../lib/minim');
+var MemberElement = minim.MemberElement;
+var ObjectSlice = minim.ObjectSlice;
+
+describe('ObjectSlice', function () {
+  it('provides map', function () {
+    var slice = new ObjectSlice([
+      new MemberElement('name', 'Doe'),
+    ]);
+
+    var result = slice.map(function (value) {
+      return value.toValue();
+    });
+
+    expect(result).to.deep.equal(['Doe']);
+  });
+
+  it('provides forEach', function () {
+    var element = new MemberElement('name', 'Doe');
+    var slice = new ObjectSlice([element]);
+
+    var keys = [];
+    var values = [];
+    var members = [];
+    var indexes = [];
+
+    slice.forEach(function (value, key, member, index) {
+      keys.push(key.toValue());
+      values.push(value.toValue());
+      members.push(member);
+      indexes.push(index);
+    });
+
+    expect(keys).to.deep.equal(['name']);
+    expect(values).to.deep.equal(['Doe']);
+    expect(members).to.deep.equal([element]);
+    expect(indexes).to.deep.equal([0]);
+  });
+
+  it('provides filter', function () {
+    var slice = new ObjectSlice([
+      new MemberElement('name', 'Doe'),
+      new MemberElement('name', 'Bill'),
+    ]);
+
+    var filtered = slice.filter(function (value) {
+      return value.toValue() === 'Doe';
+    });
+
+    expect(filtered).to.be.instanceof(ObjectSlice);
+    expect(filtered.toValue()).to.deep.equal([{key: 'name', value: 'Doe'}]);
+  });
+
+  it('provides keys', function () {
+    var element = new MemberElement('name', 'Doe');
+    var slice = new ObjectSlice([element]);
+
+    expect(slice.keys()).to.deep.equal(['name']);
+  });
+
+  it('provides values', function () {
+    var element = new MemberElement('name', 'Doe');
+    var slice = new ObjectSlice([element]);
+
+    expect(slice.values()).to.deep.equal(['Doe']);
+  });
+});

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -3,7 +3,7 @@ var expect = require('../spec-helper').expect;
 var minim = require('../../lib/minim').namespace();
 var KeyValuePair = require('../../lib/key-value-pair');
 var RefElement = require('../../lib/minim').RefElement;
-var ElementSlice = require('../../lib/minim').ElementSlice;
+var ArraySlice = require('../../lib/minim').ArraySlice;
 
 describe('Element', function() {
   context('when initializing', function() {
@@ -358,7 +358,7 @@ describe('Element', function() {
       const element = new minim.Element('value');
       const children = element.children;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(0);
     });
 
@@ -367,7 +367,7 @@ describe('Element', function() {
       const element = new minim.Element(child);
       const children = element.children;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(1);
       expect(children.get(0)).to.equal(child);
     });
@@ -379,7 +379,7 @@ describe('Element', function() {
       const element = new minim.Element([child1, child2]);
       const children = element.children;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(2);
       expect(children.get(0)).to.equal(child1);
       expect(children.get(1)).to.equal(child2);
@@ -391,7 +391,7 @@ describe('Element', function() {
 
       const children = element.children;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(1);
       expect(children.get(0)).to.equal(key);
     });
@@ -403,7 +403,7 @@ describe('Element', function() {
 
       const children = element.children;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(2);
       expect(children.get(0)).to.equal(key);
       expect(children.get(1)).to.equal(value);
@@ -417,7 +417,7 @@ describe('Element', function() {
       const element = new minim.Element('value');
       const children = element.recursiveChildren;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(0);
     });
 
@@ -427,7 +427,7 @@ describe('Element', function() {
       const element = new minim.Element(child);
       const children = element.recursiveChildren;
 
-      expect(children).to.be.instanceof(ElementSlice);
+      expect(children).to.be.instanceof(ArraySlice);
       expect(children.length).to.equal(2);
       expect(children.get(0)).to.equal(child);
       expect(children.get(1)).to.equal(childchild);
@@ -439,7 +439,7 @@ describe('Element', function() {
       const element = new minim.Element();
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.isEmpty).to.be.true;
     });
 
@@ -451,7 +451,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['Hello World']);
     });
 
@@ -467,7 +467,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['One', 'Three']);
     });
 
@@ -483,7 +483,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['key1', 'value2']);
     });
 
@@ -498,7 +498,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['Hello World']);
     });
 
@@ -514,7 +514,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['Hello World']);
     });
 
@@ -537,7 +537,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['key1', 'value2']);
     });
 
@@ -553,7 +553,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['Hello World']);
 
       const helloElement = result.get(0);
@@ -584,7 +584,7 @@ describe('Element', function() {
 
       const result = element.findRecursive('member', 'array', 'string');
 
-      expect(result).to.be.instanceof(ElementSlice);
+      expect(result).to.be.instanceof(ArraySlice);
       expect(result.toValue()).to.deep.equal(['Four']);
     });
   });


### PR DESCRIPTION
Like `ElementSlice` (now `ArraySlice`) this PR introduces `ObjectSlice` for the same reasons as https://github.com/refractproject/minim/pull/132. I've also renamed ElementSlice to become ArraySlice so that it is clearer with both types.