### PR TITLE
Implement parent element tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+## Breaking
+
 - `Element.children` and `Element.recursiveChildren` now return `ArraySlice`
   instead of an `ArrayElement`.
 - `ArrayElement.filter` and `ArrayElement.find*` now return `ArraySlice`
@@ -8,6 +10,11 @@
   instead of methods.
 - `ObjectElement.filter` now returns an `ObjectSlice` instead of an
   `ObjectElement`.
+
+## Enhancements
+
+- Every element in an element tree will now have a `parent` providing access to
+  traverse up an element tree from a child.
 
 # 0.18.1
 

--- a/README.md
+++ b/README.md
@@ -207,44 +207,6 @@ that we are recursively looking for all `string` elements that are found within 
 const stringInsideMembers = element.findRecursive('member', 'string');
 ```
 
-##### Parents
-
-Each returned element will include a new `parents` property which is an array
-element including the parents of the returned element.
-
-As an example, if I had an array element which contains a category element
-which in turn contains a string element with the content "Hello World". I can
-access the parent array and category element. The parents are in closest parent
-order.
-
-```json
-{
-  "element": "array",
-  "content": [
-    {
-      "element": "category",
-      "content": [
-        {
-          "element": "string",
-          "content": "Hello World"
-        }
-      ]
-    }
-  ]
-}
-```
-
-```javascript
-const elements = element.findRecursive('string');
-const helloString = elements.first;
-
-// Category Element
-helloString.parents[0];
-
-// Array Element
-helloString.parents[1];
-```
-
 #### children
 
 The `children` property returns an `ArrayElement` containing all of the direct children elements.

--- a/lib/key-value-pair.js
+++ b/lib/key-value-pair.js
@@ -7,6 +7,7 @@ var KeyValuePair = createClass({
   constructor: function(key, value) {
     this.key = key;
     this.value = value;
+    this.parent = null;
   },
 
   clone: function() {
@@ -21,6 +22,60 @@ var KeyValuePair = createClass({
     }
 
     return clone;
+  },
+}, {}, {
+  parent: {
+    get: function() {
+      return this._parent;
+    },
+
+    set: function(newValue) {
+      this._parent = newValue;
+
+      if (this.key) {
+        this.key.parent = newValue;
+      }
+
+      if (this.value) {
+        this.value.parent = newValue;
+      }
+    }
+  },
+
+  key: {
+    get: function() {
+      return this._key;
+    },
+
+    set: function(newValue) {
+      if (this._key) {
+        this._key.parent = null;
+      }
+
+      this._key = newValue;
+
+      if (newValue) {
+        newValue.parent = this.parent;
+      }
+    }
+  },
+
+  value: {
+    get: function() {
+      return this._value;
+    },
+
+    set: function(newValue) {
+      if (this._value) {
+        this._value.parent = null;
+      }
+
+      this._value = newValue;
+
+      if (newValue) {
+        newValue.parent = this.parent;
+      }
+    }
   }
 });
 

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -41,12 +41,29 @@ var ArrayElement = Element.extend({
   },
 
   set: function(index, value) {
-    this.content[index] = refract(value);
+    if (Object.isFrozen(this.content)) {
+      var elements = [];
+      this.content.forEach(function (element) { elements.push(element); element.parent = null; });
+      elements[index] = refract(value);
+      this.content = elements;
+    } else {
+      this.content[index] = refract(value);
+    }
+
     return this;
   },
 
   remove: function (index) {
-    var removed = this.content.splice(index, 1);
+    var removed;
+
+    if (Object.isFrozen(this.content)) {
+      var elements = [];
+      this.content.forEach(function (element) { elements.push(element); element.parent = null; });
+      removed = elements.splice(index, 1);
+      this.content = elements;
+    } else {
+      removed = this.content.splice(index, 1);
+    }
 
     if (removed.length) {
       return removed[0];
@@ -107,15 +124,38 @@ var ArrayElement = Element.extend({
   },
 
   shift: function() {
+    if (Object.isFrozen(this.content)) {
+      var elements = [];
+      this.content.forEach(function (element) { elements.push(element); element.parent = null; });
+      var result = elements.shift();
+      this.content = elements;
+      return result;
+    }
+
     return this.content.shift();
   },
 
   unshift: function(value) {
-    this.content.unshift(refract(value));
+    if (Object.isFrozen(this.content)) {
+      var elements = [];
+      this.content.forEach(function (element) { elements.push(element); element.parent = null; });
+      elements.unshift(refract(value));
+      this.content = elements;
+    } else {
+      this.content.unshift(refract(value));
+    }
   },
 
   push: function(value) {
-    this.content.push(refract(value));
+    if (Object.isFrozen(this.content)) {
+      var elements = [];
+      this.content.forEach(function (element) { elements.push(element); element.parent = null; });
+      elements.push(refract(value));
+      this.content = elements;
+    } else {
+      this.content.push(refract(value));
+    }
+
     return this;
   },
 

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -166,48 +166,28 @@ var Element = createClass({
 
   /// Finds the given elements in the element tree
   /// Returns ArraySlice of elements
-  /// findRecursive: function(names..., parents)
+  /// findRecursive: function(...names)
   findRecursive: function() {
-    var ArrayElement = require('./array-element');
     var elementNames = [].concat.apply([], arguments);
-    var elements = new ArraySlice();
-    var parents;
-
-    if (elementNames[elementNames.length - 1] instanceof ArraySlice) {
-      // clone the given parents
-      parents = new ArraySlice(elementNames.pop().map(function (e) { return e; }));
-    } else {
-      parents = new ArraySlice();
-    }
-
     var elementName = elementNames.pop();
-
-    parents.unshift(this);
+    var elements = new ArraySlice();
 
     var append = function(array, element) {
       array.push(element);
       return array;
     };
 
-    var attachParents = function(element, parents) {
-      var clonedElement = element.clone();
-      clonedElement.parents = parents;
-      return clonedElement;
-    };
-
     // Checks the given element and appends element/sub-elements
     // that match element name to given array
     var checkElement = function(array, element) {
       if (element.element === elementName) {
-        array.push(attachParents(element, parents));
+        array.push(element);
       }
 
-      var items = element.findRecursive(elementName, parents);
+      var items = element.findRecursive(elementName);
       if (items) {
         items.reduce(append, array);
       }
-
-      parents.unshift(element);
 
       if (element.content instanceof KeyValuePair) {
         if (element.content.key) {
@@ -218,8 +198,6 @@ var Element = createClass({
           checkElement(array, element.content.value);
         }
       }
-
-      parents.shift();
 
       return array;
     };
@@ -247,7 +225,7 @@ var Element = createClass({
           var index = parentElements.indexOf(name);
 
           if (index !== -1) {
-            parentElements.splice(0, index);
+            parentElements = parentElements.splice(0, index);
           } else {
             return false;
           }

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -19,6 +19,7 @@ var Element = createClass({
     }
 
     this.content = content !== undefined ? content : null;
+    this.parent = null;
   },
 
   primitive: function() {
@@ -238,6 +239,46 @@ var Element = createClass({
       } else {
         this.meta.set(value || {});
       }
+    }
+  },
+
+  content: {
+    get: function() {
+      return this._content;
+    },
+
+    set: function(newValue) {
+      if (this._content instanceof Element || this._content instanceof KeyValuePair) {
+        this._content.parent = null;
+      } else if (Array.isArray(this._content)) {
+        this._content.forEach(function (value) {
+          value.parent = null;
+        }, this);
+      }
+
+      this._content = newValue;
+
+      if (newValue instanceof Element || newValue instanceof KeyValuePair) {
+        newValue.parent = this;
+      } else if (Array.isArray(newValue)) {
+        newValue.forEach(function (value) {
+          value.parent = this;
+        }, this);
+      }
+    }
+  },
+
+  parent: {
+    get: function() {
+      return this._parent;
+    },
+
+    set: function(newValue) {
+      if (newValue && this._parent) {
+        throw new Error('Cannot set a new parent, element already has parent');
+      }
+
+      this._parent = newValue;
     }
   },
 

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -6,6 +6,75 @@ var createClass = uptown.createClass;
 var KeyValuePair = require('../key-value-pair');
 var ArraySlice = require('../array-slice.js');
 
+// Returns a handler for a Proxy of an Array which hooks mutation to
+// update `.parent` property of elements inside the Array.
+function proxyArrayHandler (parent) {
+  return {
+    get: function (target, property, receiver) {
+      var overrides = {
+        push: function () {
+          var result = target.push.apply(target, arguments);
+
+          var elements = [].concat.apply([], arguments);
+          elements.forEach(function (element) {
+            element.parent = parent;
+          });
+
+          return result;
+        },
+
+        unshift: function () {
+          var result = target.unshift.apply(target, arguments);
+
+          var elements = [].concat.apply([], arguments);
+          elements.forEach(function (element) {
+            element.parent = parent;
+          });
+
+          return result;
+        },
+
+        pop: function () {
+          var element = target.pop();
+
+          if (element) {
+            element.parent = null;
+          }
+
+          return element;
+        },
+
+        shift: function () {
+          var element = target.shift();
+
+          if (element) {
+            element.parent = null;
+          }
+
+          return element;
+        },
+
+        splice: function () {
+          var inserting = Array.prototype.slice.call(arguments, 2);
+          var result = target.splice.apply(target, arguments);
+
+          result.forEach(function (element) {
+            element.parent = null;
+          });
+
+          inserting.forEach(function (element) {
+            element.parent = parent;
+          });
+
+          return result;
+        },
+      };
+
+      return overrides[property] || target[property];
+    },
+  };
+}
+
 var Element = createClass({
   constructor: function(content, meta, attributes) {
     // Lazy load this.meta and this.attributes because it's a Minim element
@@ -264,6 +333,8 @@ var Element = createClass({
         newValue.forEach(function (value) {
           value.parent = this;
         }, this);
+
+        this._content = new Proxy(newValue, proxyArrayHandler(this));
       }
     }
   },

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -353,6 +353,20 @@ var Element = createClass({
     }
   },
 
+  parents: {
+    get: function() {
+      var parent = this.parent;
+      var parents = new ArraySlice();
+
+      while (parent) {
+        parents.push(parent);
+        parent = parent.parent;
+      }
+
+      return parents;
+    }
+  },
+
   attributes: {
     get: function() {
       if (!this._attributes) {

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -312,7 +312,15 @@ var Element = createClass({
           value.parent = this;
         }, this);
 
-        this._content = new Proxy(newValue, proxyArrayHandler(this));
+        if (global['Proxy']) {
+          this._content = new Proxy(newValue, proxyArrayHandler(this));
+        } else {
+          // Proxy is not available (Node 4), this means we cannot observe an array for changes.
+          // Since we cannot properly update parents without observing for changes we will
+          // freeze the content so that no one will mutate the content directly without using
+          // the ArrayElement convience methods
+          Object.freeze(this._content);
+        }
       }
     }
   },

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -95,7 +95,7 @@ var ObjectElement = ArrayElement.extend({
     if (member) {
       member.value = value;
     } else {
-      this.content.push(new MemberElement(key, value));
+      this.push(new MemberElement(key, value));
     }
 
     return this;

--- a/test/key-value-pair-tests.js
+++ b/test/key-value-pair-tests.js
@@ -1,0 +1,41 @@
+var _ = require('lodash');
+var expect = require('./spec-helper').expect;
+var Element = require('../lib/minim').Element;
+var KeyValuePair = require('../lib/key-value-pair');
+
+describe('KeyValuePair', function() {
+  it('can be initialised with a key and value', function() {
+    var key = new Element('key');
+    var value = new Element('value');
+    var pair = new KeyValuePair(key, value);
+
+    expect(pair.key).to.equal(key);
+    expect(pair.value).to.equal(value);
+  });
+
+  it('updates key parent when setting new key', function() {
+    var key = new Element('key');
+    var newKey = new Element('new key');
+    var parent = new Element('parent');
+    var pair = new KeyValuePair(key, null);
+    pair.parent = parent;
+
+    pair.key = newKey;
+
+    expect(key.parent).to.be.null;
+    expect(newKey.parent).to.be.equal(parent);
+  });
+
+  it('updates value parent when setting new value', function() {
+    var value = new Element('value');
+    var newValue = new Element('new value');
+    var parent = new Element('parent');
+    var pair = new KeyValuePair(null, value);
+    pair.parent = parent;
+
+    pair.value = newValue;
+
+    expect(value.parent).to.be.null;
+    expect(newValue.parent).to.be.equal(parent);
+  });
+});

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -745,128 +745,132 @@ describe('Element', function() {
       expect(child.parent).to.be.null;
     });
 
-    it('configures parent when setting element content to be array of element', function () {
-      var element = new minim.Element('parent');
-      var child = new minim.Element('child');
+    if (global['Proxy']) {
+      it('configures parent when setting element content to be array of element', function () {
+        var element = new minim.Element('parent');
+        var child = new minim.Element('child');
 
-      element.content = [child];
+        element.content = [child];
 
-      expect(child.parent).to.be.equal(element);
-    });
+        expect(child.parent).to.be.equal(element);
+      });
 
-    it('removes parent when unsetting element content from array containing an element', function () {
-      var element = new minim.Element('parent');
-      var child = new minim.Element('child');
+      it('removes parent when unsetting element content from array containing an element', function () {
+        var element = new minim.Element('parent');
+        var child = new minim.Element('child');
 
-      element.content = [child];
-      element.content = null;
+        element.content = [child];
+        element.content = null;
 
-      expect(child.parent).to.be.null;
-    });
+        expect(child.parent).to.be.null;
+      });
 
-    it('configures parent when setting element content to be key value pair', function () {
-      var element = new minim.Element('parent');
-      var key = new minim.Element('key');
-      var value = new minim.Element('value');
+      it('configures parent when setting element content to be key value pair', function () {
+        var element = new minim.Element('parent');
+        var key = new minim.Element('key');
+        var value = new minim.Element('value');
 
-      element.content = new KeyValuePair(key, value);
+        element.content = new KeyValuePair(key, value);
 
-      expect(key.parent).to.be.equal(element);
-      expect(value.parent).to.be.equal(element);
-    });
+        expect(key.parent).to.be.equal(element);
+        expect(value.parent).to.be.equal(element);
+      });
 
-    it('removes parent when unsetting element content from key value pair', function () {
-      var element = new minim.Element('parent');
-      var key = new minim.Element('key');
-      var value = new minim.Element('value');
+      it('removes parent when unsetting element content from key value pair', function () {
+        var element = new minim.Element('parent');
+        var key = new minim.Element('key');
+        var value = new minim.Element('value');
 
-      element.content = new KeyValuePair(key, value);
-      element.content = null;
+        element.content = new KeyValuePair(key, value);
+        element.content = null;
 
-      expect(key.parent).to.be.null;
-      expect(value.parent).to.be.null;
-    });
+        expect(key.parent).to.be.null;
+        expect(value.parent).to.be.null;
+      });
 
-    it('errors when setting parent for element that has a previous parent', function () {
-      var child = new minim.Element('child');
-      var parent = new minim.Element(child);
+      it('errors when setting parent for element that has a previous parent', function () {
+        var child = new minim.Element('child');
+        var parent = new minim.Element(child);
 
-      expect(function () { child.parent = new minim.Element(); }).to.throw();
-    });
+        expect(function () { child.parent = new minim.Element(); }).to.throw();
+      });
 
-    it('sets parent for elements pushed onto a content array', function () {
-      var child1 = new minim.Element('one');
-      var child2 = new minim.Element('two');
-      var child3 = new minim.Element('three');
-      var array = new minim.Element([child1]);
+      it('sets parent for elements pushed onto a content array', function () {
+        var child1 = new minim.Element('one');
+        var child2 = new minim.Element('two');
+        var child3 = new minim.Element('three');
+        var array = new minim.Element([child1]);
 
-      var result = array.content.push(child2, child3);
+        var result = array.content.push(child2, child3);
 
-      expect(result).to.equal(3);
-      expect(array.content).to.deep.equal([child1, child2, child3]);
+        expect(result).to.equal(3);
+        expect(array.content).to.deep.equal([child1, child2, child3]);
 
-      expect(child1.parent).to.be.equal(array);
-      expect(child2.parent).to.be.equal(array);
-    });
+        expect(child1.parent).to.be.equal(array);
+        expect(child2.parent).to.be.equal(array);
+      });
 
-    it('sets parent for elements unshifted onto a content array', function () {
-      var child1 = new minim.Element('one');
-      var child2 = new minim.Element('two');
-      var child3 = new minim.Element('three');
-      var array = new minim.Element([child1]);
+      it('sets parent for elements unshifted onto a content array', function () {
+        var child1 = new minim.Element('one');
+        var child2 = new minim.Element('two');
+        var child3 = new minim.Element('three');
+        var array = new minim.Element([child1]);
 
-      var result = array.content.unshift(child2, child3);
+        var result = array.content.unshift(child2, child3);
 
-      expect(result).to.equal(3);
-      expect(array.content).to.deep.equal([child2, child3, child1]);
+        expect(result).to.equal(3);
+        expect(array.content).to.deep.equal([child2, child3, child1]);
 
-      expect(child1.parent).to.be.equal(array);
-      expect(child2.parent).to.be.equal(array);
-    });
+        console.log(array.content);
 
-    it('removes parent for elements popped from a content array', function () {
-      var child = new minim.Element();
-      var array = new minim.Element([child]);
+        expect(child2.parent).to.be.equal(array);
+        expect(child3.parent).to.be.equal(array);
+      });
 
-      array.content.pop();
+      it('removes parent for elements popped from a content array', function () {
+        var child = new minim.Element('xxx');
+        var array = new minim.Element([child]);
 
-      expect(child.parent).to.be.null;
-    });
+        array.content.pop();
 
-    it('removes parent for elements shifted from a content array', function () {
-      var child = new minim.Element();
-      var array = new minim.Element([child]);
+        expect(child.parent).to.be.null;
+      });
 
-      array.content.shift();
+      it('removes parent for elements shifted from a content array', function () {
+        var child = new minim.Element();
+        var array = new minim.Element([child]);
 
-      expect(child.parent).to.be.null;
-    });
+        array.content.shift();
 
-    it('removes parent for elements spliced from a content array', function () {
-      var child1 = new minim.Element('one');
-      var child2 = new minim.Element('two');
-      var child3 = new minim.Element('three');
-      var array = new minim.Element([child1, child2, child3]);
+        expect(child.parent).to.be.null;
+      });
 
-      var result = array.content.splice(1, 1);
+      it('removes parent for elements spliced from a content array', function () {
+        var child1 = new minim.Element('one');
+        var child2 = new minim.Element('two');
+        var child3 = new minim.Element('three');
+        var array = new minim.Element([child1, child2, child3]);
 
-      expect(result).to.deep.equal([child2]);
-      expect(child2.parent).to.be.null;
-    });
+        var result = array.content.splice(1, 1);
 
-    it('adds parent for elements spliced into a content array', function () {
-      var child1 = new minim.Element('one');
-      var child2 = new minim.Element('two');
-      var child3 = new minim.Element('three');
-      var child4 = new minim.Element('four');
-      var array = new minim.Element([child1, child2, child3]);
+        expect(result).to.deep.equal([child2]);
+        expect(child2.parent).to.be.null;
+      });
 
-      var result = array.content.splice(1, 1, child4);
+      it('adds parent for elements spliced into a content array', function () {
+        var child1 = new minim.Element('one');
+        var child2 = new minim.Element('two');
+        var child3 = new minim.Element('three');
+        var child4 = new minim.Element('four');
+        var array = new minim.Element([child1, child2, child3]);
 
-      expect(result).to.deep.equal([child2]);
-      expect(array.content).to.deep.equal([child1, child4, child3]);
-      expect(child4.parent).to.be.equal(array);
-    });
+        var result = array.content.splice(1, 1, child4);
+
+        expect(result).to.deep.equal([child2]);
+        expect(array.content).to.deep.equal([child1, child4, child3]);
+        expect(child4.parent).to.be.equal(array);
+      });
+    }
   });
 
   describe('#parents', function () {

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -868,4 +868,15 @@ describe('Element', function() {
       expect(child4.parent).to.be.equal(array);
     });
   });
+
+  describe('#parents', function () {
+    it('configures parent when setting element content to be an element', function () {
+      var one = new minim.Element('bottom');
+      var two = new minim.Element(one);
+      var three = new minim.Element(two);
+
+      expect(one.parents).to.be.instanceof(ArraySlice);
+      expect(one.parents.elements).to.deep.equal([two, three]);
+    });
+  });
 });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -55,6 +55,11 @@ describe('Element', function() {
       el = new minim.Element(false);
       expect(el.toValue()).to.equal(false);
     });
+
+    it('should set parent to null', function() {
+      var element = new minim.Element('');
+      expect(element.parent).to.be.null;
+    });
   });
 
   describe('#meta', function() {
@@ -717,6 +722,76 @@ describe('Element', function() {
       var element = new minim.Element();
 
       expect(function() { element.toRef(); }).to.throw();
+    });
+  });
+
+  describe('#parent', function () {
+    it('configures parent when setting element content to be an element', function () {
+      var element = new minim.Element('parent');
+      var child = new minim.Element('child');
+
+      element.content = child;
+
+      expect(child.parent).to.be.equal(element);
+    });
+
+    it('removes parent when unsetting element content from an element', function () {
+      var element = new minim.Element('parent');
+      var child = new minim.Element('child');
+
+      element.content = child;
+      element.content = null;
+
+      expect(child.parent).to.be.null;
+    });
+
+    it('configures parent when setting element content to be array of element', function () {
+      var element = new minim.Element('parent');
+      var child = new minim.Element('child');
+
+      element.content = [child];
+
+      expect(child.parent).to.be.equal(element);
+    });
+
+    it('removes parent when unsetting element content from array containing an element', function () {
+      var element = new minim.Element('parent');
+      var child = new minim.Element('child');
+
+      element.content = [child];
+      element.content = null;
+
+      expect(child.parent).to.be.null;
+    });
+
+    it('configures parent when setting element content to be key value pair', function () {
+      var element = new minim.Element('parent');
+      var key = new minim.Element('key');
+      var value = new minim.Element('value');
+
+      element.content = new KeyValuePair(key, value);
+
+      expect(key.parent).to.be.equal(element);
+      expect(value.parent).to.be.equal(element);
+    });
+
+    it('removes parent when unsetting element content from key value pair', function () {
+      var element = new minim.Element('parent');
+      var key = new minim.Element('key');
+      var value = new minim.Element('value');
+
+      element.content = new KeyValuePair(key, value);
+      element.content = null;
+
+      expect(key.parent).to.be.null;
+      expect(value.parent).to.be.null;
+    });
+
+    it('errors when setting parent for element that has a previous parent', function () {
+      var child = new minim.Element('child');
+      var parent = new minim.Element(child);
+
+      expect(function () { child.parent = new minim.Element(); }).to.throw();
     });
   });
 });

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -793,5 +793,79 @@ describe('Element', function() {
 
       expect(function () { child.parent = new minim.Element(); }).to.throw();
     });
+
+    it('sets parent for elements pushed onto a content array', function () {
+      var child1 = new minim.Element('one');
+      var child2 = new minim.Element('two');
+      var child3 = new minim.Element('three');
+      var array = new minim.Element([child1]);
+
+      var result = array.content.push(child2, child3);
+
+      expect(result).to.equal(3);
+      expect(array.content).to.deep.equal([child1, child2, child3]);
+
+      expect(child1.parent).to.be.equal(array);
+      expect(child2.parent).to.be.equal(array);
+    });
+
+    it('sets parent for elements unshifted onto a content array', function () {
+      var child1 = new minim.Element('one');
+      var child2 = new minim.Element('two');
+      var child3 = new minim.Element('three');
+      var array = new minim.Element([child1]);
+
+      var result = array.content.unshift(child2, child3);
+
+      expect(result).to.equal(3);
+      expect(array.content).to.deep.equal([child2, child3, child1]);
+
+      expect(child1.parent).to.be.equal(array);
+      expect(child2.parent).to.be.equal(array);
+    });
+
+    it('removes parent for elements popped from a content array', function () {
+      var child = new minim.Element();
+      var array = new minim.Element([child]);
+
+      array.content.pop();
+
+      expect(child.parent).to.be.null;
+    });
+
+    it('removes parent for elements shifted from a content array', function () {
+      var child = new minim.Element();
+      var array = new minim.Element([child]);
+
+      array.content.shift();
+
+      expect(child.parent).to.be.null;
+    });
+
+    it('removes parent for elements spliced from a content array', function () {
+      var child1 = new minim.Element('one');
+      var child2 = new minim.Element('two');
+      var child3 = new minim.Element('three');
+      var array = new minim.Element([child1, child2, child3]);
+
+      var result = array.content.splice(1, 1);
+
+      expect(result).to.deep.equal([child2]);
+      expect(child2.parent).to.be.null;
+    });
+
+    it('adds parent for elements spliced into a content array', function () {
+      var child1 = new minim.Element('one');
+      var child2 = new minim.Element('two');
+      var child3 = new minim.Element('three');
+      var child4 = new minim.Element('four');
+      var array = new minim.Element([child1, child2, child3]);
+
+      var result = array.content.splice(1, 1, child4);
+
+      expect(result).to.deep.equal([child2]);
+      expect(array.content).to.deep.equal([child1, child4, child3]);
+      expect(child4.parent).to.be.equal(array);
+    });
   });
 });

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -275,7 +275,7 @@ describe('ObjectElement', function() {
 
     it('allows for reducing on keys', function() {
       var letters = numbers.reduce(function(result, item, key) {
-        return result.push(key);
+        return result.push(key.clone());
       }, []);
       expect(letters.toValue()).to.deep.equal(['a', 'b', 'c', 'd']);
     });


### PR DESCRIPTION
Supersedes https://github.com/refractproject/minim/pull/58

This PR adds `parent` and `parents` properties to all elements which allows parent traversal of an element in an element tree. We only support adding an element to a single tree and if the user tries to add the element to more than one element tree we will raise an exception.

- https://github.com/refractproject/minim/commit/4f59e7d62c2a50ad2a3f25d5617248f10c2d5278 Adds basically parent tracking
- https://github.com/refractproject/minim/commit/e2b056e01508559e58cacf74e1c4e58648313745 uses Proxy to observe content arrays for changes and update the `parent` property as necessary when a user tries to mutate an array set in `content` of an element.
- https://github.com/refractproject/minim/commit/2cab0094f576caa7be1ab57192da9b4b2eb3c45f adds a convince properties `parents` which returns all of the parents upwards for the element.
- https://github.com/refractproject/minim/commit/5e909f6cfa0497d4e206aad124e4b13bbaecaf4b removes the custom parent tracking in `findRecursive` in favour of the global element parent tracking.
- https://github.com/refractproject/minim/commit/12c3a63268a30717c429df37474cae3a3bcb6cb6 Unfortunately I discovered that `Proxy` is not available on Node 4 (without `--harmony-proxioes` node argument) so I have disabled its use. Please see commit message for all details. This is very problematic for Node 4 and introduces a tricky workaround.

Please review per-commit and see the commit messages for details.