### PR TITLE
Deserialise dataStructure containing an array

### DIFF
--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -164,6 +164,8 @@ module.exports = createClass({
         defaultValue = defaultValue.get(0);
         element.attributes.set('default', defaultValue);
       }
+    } else if (element.element === 'dataStructure' && Array.isArray(element.content)) {
+      element.content = element.content[0];
     }
 
     return element;

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -560,5 +560,18 @@ describe('JSON Serialiser', function() {
       var deserializedEnum = serialiser.deserialise(serialiser.serialise(enumeration));
       expect(minim.toRefract(deserializedEnum)).to.deep.equal(minim.toRefract(enumeration));
     });
+
+    it('deserialises data structure inside an array', function() {
+      var dataStructure = serialiser.deserialise({
+        element: 'dataStructure',
+        content: [
+          {
+            element: 'string'
+          }
+        ]
+      });
+
+      expect(dataStructure.content).to.be.instanceof(minim.elements.String);
+    });
   });
 });


### PR DESCRIPTION
This was missing from previous implementation. Data structures were deserialised as array content.