### PR TITLE
Add jsdoc to public interfaces

### DIFF
--- a/lib/array-slice.js
+++ b/lib/array-slice.js
@@ -5,12 +5,22 @@ var uptown = require('uptown');
 var refract = require('./refraction').refract;
 var createClass = uptown.createClass;
 
+/**
+ * @class
+ *
+ * @param {Element[]} elements
+ *
+ * @property {Element[]} elements
+ */
 var ArraySlice = createClass({
-  // elements: [Element]
   constructor: function (elements) {
     this.elements = elements || [];
   },
 
+  /**
+   * @returns {Array}
+   * @memberof ArraySlice.prototype
+   */
   toValue: function () {
     return this.elements.map(function (element) {
       return element.toValue();
@@ -19,24 +29,49 @@ var ArraySlice = createClass({
 
   // High Order Functions
 
+  /**
+   * @param callback - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @returns {array} A new array with each element being the result of the callback function
+   * @memberof ArraySlice.prototype
+   */
   map: function (callback, thisArg) {
     return this.elements.map(callback, thisArg);
   },
 
-  // Filters the element slice
-  // Returns a new sub slice
+  /**
+   * @param callback - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @returns {ArraySlice}
+   * @memberof ArraySlice.prototype
+   */
   filter: function (callback, thisArg) {
     return new ArraySlice(this.elements.filter(callback, thisArg));
   },
 
+  /**
+   * @param callback - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @memberof ArraySlice.prototype
+   */
   forEach: function (callback, thisArg) {
     this.elements.forEach(callback, thisArg);
   },
 
+  /**
+   * @param callback - Function to execute for each element
+   * @param initialValue
+   * @memberof ArraySlice.prototype
+   */
   reduce: function (callback, initialValue) {
     return this.elements.reduce(callback, initialValue);
   },
 
+  /**
+   * @param value
+   * @returns {boolean}
+   * @memberof ArraySlice.prototype
+   */
   includes: function(value) {
     for (var i = 0; i < this.length; i++) {
       var item = this.elements[i];
@@ -50,29 +85,57 @@ var ArraySlice = createClass({
 
   // Mutation
 
+  /**
+   * Removes the first element from the slice
+   * @returns {Element} The removed element or undefined if the slice is empty
+   * @memberof ArraySlice.prototype
+   */
   shift: function() {
     return this.elements.shift();
   },
 
+  /**
+   * Adds the given element to the begining of the slice
+   * @parameter {Element}
+   * @memberof ArraySlice.prototype
+   */
   unshift: function(value) {
     this.elements.unshift(refract(value));
   },
 
+  /**
+   * Adds the given element to the end of the slice
+   * @parameter {Element}
+   * @memberof ArraySlice.prototype
+   */
   push: function(value) {
     this.elements.push(refract(value));
     return this;
   },
 
+  /**
+   * @parameter {Element}
+   * @memberof ArraySlice.prototype
+   */
   add: function(value) {
     this.push(value);
   },
 
   // Accessors
 
+  /**
+   * @parameter {number}
+   * @returns {Element}
+   * @memberof ArraySlice.prototype
+   */
   get: function(index) {
     return this.elements[index];
   },
 
+  /**
+   * @parameter {number}
+   * @memberof ArraySlice.prototype
+   */
   getValue: function(index) {
     var element = this.elements[index];
 
@@ -83,18 +146,36 @@ var ArraySlice = createClass({
     return undefined;
   }
 }, {}, {
+  /**
+   * Returns the number of elements in the slice
+   * @type number
+   * @readonly
+   * @memberof ArraySlice.prototype
+   */
   length: {
     get: function () {
       return this.elements.length;
     }
   },
 
+  /**
+   * Returns whether the slice is empty
+   * @type boolean
+   * @readonly
+   * @memberof ArraySlice.prototype
+   */
   isEmpty: {
     get: function() {
       return this.elements.length === 0;
     }
   },
 
+  /**
+   * Returns the first element in the slice or undefined if the slice is empty
+   * @type Element
+   * @readonly
+   * @memberof ArraySlice.prototype
+   */
   first: {
     get: function() {
       return this.elements[0];

--- a/lib/elements/link-element.js
+++ b/lib/elements/link-element.js
@@ -2,12 +2,25 @@
 
 var Element = require('../primitives/element');
 
+/**
+ * @class LinkElement
+ *
+ * @param content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function(content, meta, attributes) {
     Element.call(this, content || [], meta, attributes);
     this.element = 'link';
   }
 }, {}, {
+  /**
+   * @type StringElement
+   * @memberof LinkElement.prototype
+   */
   relation: {
     get: function() {
       return this.attributes.get('relation');
@@ -17,6 +30,10 @@ module.exports = Element.extend({
     }
   },
 
+  /**
+   * @type StringElement
+   * @memberof LinkElement.prototype
+   */
   href: {
     get: function() {
       return this.attributes.get('href');

--- a/lib/elements/ref-element.js
+++ b/lib/elements/ref-element.js
@@ -2,6 +2,15 @@
 
 var Element = require('../primitives/element');
 
+/**
+ * @class RefElement
+ *
+ * @param content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function(content, meta, attributes) {
     Element.call(this, content || [], meta, attributes);
@@ -12,6 +21,10 @@ module.exports = Element.extend({
     }
   }
 }, {}, {
+  /**
+   * @type StringElement
+   * @memberof RefElement.prototype
+   */
   path: {
     get: function() {
       return this.attributes.get('path');

--- a/lib/key-value-pair.js
+++ b/lib/key-value-pair.js
@@ -3,12 +3,22 @@
 var uptown = require('uptown');
 var createClass = uptown.createClass;
 
+/**
+ * @class
+ *
+ * @property {Element} key
+ * @property {Element} value
+ */
 var KeyValuePair = createClass({
   constructor: function(key, value) {
     this.key = key;
     this.value = value;
   },
 
+  /**
+   * @returns {KeyValuePair}
+   * @memberof KeyValuePair
+   */
   clone: function() {
     var clone = new KeyValuePair();
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -4,7 +4,9 @@ var _ = require('lodash');
 var uptown = require('uptown');
 var createClass = uptown.createClass;
 
-/*
+/**
+ * @class
+ *
  * A refract element implementation with an extensible namespace, able to
  * load other namespaces into it.
  *
@@ -12,7 +14,6 @@ var createClass = uptown.createClass;
  * when a particular refract element is encountered, and allows you to specify
  * which elements get instantiated for existing Javascript objects.
  */
-
 var Namespace = createClass({
   constructor: function(options) {
     this.elementMap = {};
@@ -28,8 +29,12 @@ var Namespace = createClass({
     this._attributeElementArrayKeys = [];
   },
 
-  /*
+  /**
    * Use a namespace plugin or load a generic plugin.
+   *
+   * @param plugin
+   *
+   * @memberof Namespace.prototype
    */
   use: function(plugin) {
     if (plugin.namespace) {
@@ -83,16 +88,25 @@ var Namespace = createClass({
     return this;
   },
 
-  /*
+  /**
    * Register a new element class for an element.
+   *
+   * @param {string} name
+   * @param elementClass
+   *
+   * @memberof Namespace.prototype
    */
   register: function(name, ElementClass) {
     this.elementMap[name] = ElementClass;
     return this;
   },
 
-  /*
+  /**
    * Unregister a previously registered class for an element.
+   *
+   * @param {string} name
+   *
+   * @memberof Namespace.prototype
    */
   unregister: function(name) {
     delete this.elementMap[name];
@@ -193,8 +207,15 @@ var Namespace = createClass({
     }
   },
 
-  // Convinience method for getting a JSON Serialiser configured with the
-  // current namespace
+  /**
+   * Convinience method for getting a JSON Serialiser configured with the
+   * current namespace
+   *
+   * @type JSONSerialiser
+   * @readonly
+   *
+   * @memberof Namespace.prototype
+   */
   serialiser: {
     get: function() {
       var JSONSerialiser = require('./serialisers/json');

--- a/lib/object-slice.js
+++ b/lib/object-slice.js
@@ -3,6 +3,10 @@
 var _ = require('lodash');
 var ArraySlice = require('./array-slice');
 
+/**
+ * @class
+ * @extends ArraySlice
+ */
 var ObjectSlice = ArraySlice.extend({
   map: function(callback, thisArg) {
     return this.elements.map(function(member) {
@@ -22,12 +26,20 @@ var ObjectSlice = ArraySlice.extend({
     }, thisArg);
   },
 
+  /**
+   * @returns {array}
+   * @memberof ObjectSlice.prototype
+   */
   keys: function() {
     return this.map(function(value, key) {
       return key.toValue();
     });
   },
 
+  /**
+   * @returns {array}
+   * @memberof ObjectSlice.prototype
+   */
   values: function() {
     return this.map(function(value) {
       return value.toValue();

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -5,6 +5,15 @@ var refract = require('../refraction').refract;
 var Element = require('./element');
 var ArraySlice = require('../array-slice');
 
+/**
+ * @class
+ *
+ * @param {Element[]} content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 var ArrayElement = Element.extend({
   constructor: function (content, meta, attributes) {
     var convertedContent = (content || []).map(function(value) {
@@ -18,13 +27,17 @@ var ArrayElement = Element.extend({
     return 'array';
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   get: function(index) {
     return this.content[index];
   },
 
-  /*
+  /**
    * Helper for returning the value of an item
    * This works for both ArrayElement and ObjectElement instances
+   * @memberof ArrayElement.prototype
    */
   getValue: function(indexOrKey) {
     var item = this.get(indexOrKey);
@@ -36,15 +49,24 @@ var ArrayElement = Element.extend({
     return undefined;
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   getIndex: function(index) {
     return this.content[index];
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   set: function(index, value) {
     this.content[index] = refract(value);
     return this;
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   remove: function (index) {
     var removed = this.content.splice(index, 1);
 
@@ -55,18 +77,30 @@ var ArrayElement = Element.extend({
     return null;
   },
 
+  /**
+   * @param callback - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @memberof ArrayElement.prototype
+   */
   map: function(callback, thisArg) {
     return this.content.map(callback, thisArg);
   },
 
+  /**
+   * @param callback - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @returns {ArraySlice}
+   * @memberof ArrayElement.prototype
+   */
   filter: function(callback, thisArg) {
     return new ArraySlice(this.content.filter(callback, thisArg));
   },
 
-  /*
+  /**
    * This is a reduce function specifically for Minim arrays and objects. It
    * allows for returning normal values or Minim instances, so it converts any
    * primitives on each step.
+   * @memberof MemberElement.prototype
    */
   reduce: function(callback, initialValue) {
     var startIndex;
@@ -100,29 +134,57 @@ var ArrayElement = Element.extend({
     return memo;
   },
 
+  /**
+   * @callback forEachCallback
+   * @param {Element} currentValue
+   * @param {NumberElement} index
+   */
+
+  /**
+   * @param {forEachCallback} - Function to execute for each element
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   * @memberof ArrayElement.prototype
+   */
   forEach: function(callback, thisArg) {
     this.content.forEach(function(item, index) {
       callback(item, refract(index));
     }, thisArg);
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   shift: function() {
     return this.content.shift();
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   unshift: function(value) {
     this.content.unshift(refract(value));
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   push: function(value) {
     this.content.push(refract(value));
     return this;
   },
 
+  /**
+   * @memberof ArrayElement.prototype
+   */
   add: function(value) {
     this.push(value);
   },
 
+  /**
+   * Recusively search all descendents using a condition function.
+   * @returns {array[Element]}
+   * @memberof ArrayElement.prototype
+   */
   findElements: function(condition, givenOptions) {
     var options = givenOptions || {};
     var recursive = !!options.recursive;
@@ -148,27 +210,39 @@ var ArrayElement = Element.extend({
     return results;
   },
 
-  /*
+  /**
    * Recusively search all descendents using a condition function.
+   * @returns {ArraySlice}
+   * @memberof ArrayElement.prototype
    */
   find: function(condition) {
     return new ArraySlice(this.findElements(condition, {recursive: true}));
   },
 
+  /**
+   * @returns {ArraySlice}
+   * @memberof ArrayElement.prototype
+   */
   findByElement: function(element) {
     return this.find(function(item) {
       return item.element === element;
     });
   },
 
+  /**
+   * @returns {ArraySlice}
+   * @memberof ArrayElement.prototype
+   */
   findByClass: function(className) {
     return this.find(function(item) {
       return item.classes.contains(className);
     });
   },
 
-  /*
+  /**
    * Search the tree recursively and find the element with the matching ID
+   * @returns {Element}
+   * @memberof ArrayElement.prototype
    */
   getById: function(id) {
     return this.find(function(item) {
@@ -176,8 +250,10 @@ var ArrayElement = Element.extend({
     }).first;
   },
 
-  /*
+  /**
    * Looks for matching children using deep equality
+   * @returns {boolean}
+   * @memberof ArrayElement.prototype
    */
   contains: function(value) {
     for (var i = 0; i < this.content.length; i++) {
@@ -190,20 +266,33 @@ var ArrayElement = Element.extend({
     return false;
   }
 }, {}, {
+  /**
+   * @type number
+   * @readonly
+   * @memberof ArrayElement.prototype
+   */
   length: {
     get: function() {
       return this.content.length;
     }
   },
 
+  /**
+   * @type boolean
+   * @readonly
+   * @memberof ArrayElement.prototype
+   */
   isEmpty: {
     get: function() {
       return this.content.length === 0;
     }
   },
 
-  /*
+  /**
    * Return the first item in the collection
+   * @type Element
+   * @readonly
+   * @memberof ArrayElement.prototype
    */
   first: {
     get: function () {
@@ -211,8 +300,11 @@ var ArrayElement = Element.extend({
     },
   },
 
-  /*
+  /**
    * Return the second item in the collection
+   * @type Element
+   * @readonly
+   * @memberof ArrayElement.prototype
    */
   second: {
     get: function() {
@@ -220,8 +312,11 @@ var ArrayElement = Element.extend({
     },
   },
 
-  /*
+  /**
    * Return the last item in the collection
+   * @type Element
+   * @readonly
+   * @memberof ArrayElement.prototype
    */
   last: {
     get: function() {

--- a/lib/primitives/boolean-element.js
+++ b/lib/primitives/boolean-element.js
@@ -2,6 +2,15 @@
 
 var Element = require('./element');
 
+/**
+ * @class BooleanElement
+ *
+ * @param {boolean} content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function() {
     Element.apply(this, arguments);

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -6,6 +6,15 @@ var createClass = uptown.createClass;
 var KeyValuePair = require('../key-value-pair');
 var ArraySlice = require('../array-slice.js');
 
+/**
+ * @class
+ *
+ * @param content
+ * @param meta
+ * @param attributes
+ *
+ * @property {string} element
+ */
 var Element = createClass({
   constructor: function(content, meta, attributes) {
     // Lazy load this.meta and this.attributes because it's a Minim element
@@ -25,8 +34,9 @@ var Element = createClass({
     return;
   },
 
-  /*
+  /**
    * Creates a deep clone of the instance
+   * @memberof Element.prototype
    */
   clone: function() {
     var copy = new this.constructor();
@@ -58,6 +68,9 @@ var Element = createClass({
     return copy;
   },
 
+  /**
+   * @memberof Element.prototype
+   */
   toValue: function() {
     if (this.content instanceof Element) {
       return this.content.toValue();
@@ -79,6 +92,11 @@ var Element = createClass({
     return this.content;
   },
 
+  /**
+   * Creates a reference pointing at the Element
+   * @returns {RefElement}
+   * @memberof Element.prototype
+   */
   toRef: function(path) {
     if (this.id.toValue() === '') {
       throw Error('Cannot create reference to an element that does not contain an ID');
@@ -94,9 +112,12 @@ var Element = createClass({
     return ref;
   },
 
-  /// Finds the given elements in the element tree
-  /// Returns ArraySlice of elements
-  /// findRecursive: function(names..., parents)
+  /**
+   * Finds the given elements in the element tree
+   * @param {...elementNames}
+   * @returns {ArraySlice}
+   * @memberof Element.prototype
+   */
   findRecursive: function() {
     var ArrayElement = require('./array-element');
     var elementNames = [].concat.apply([], arguments);
@@ -211,6 +232,10 @@ var Element = createClass({
     this.meta.set(name, value);
   }
 }, {}, {
+  /**
+   * @type String
+   * @memberof Element.prototype
+   */
   element: {
     get: function() {
       // Returns 'element' so we don't have undefined as element
@@ -221,6 +246,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ObjectElement
+   * @memberof Element.prototype
+   */
   meta: {
     get: function() {
       if (!this._meta) {
@@ -241,6 +270,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ObjectElement
+   * @memberof Element.prototype
+   */
   attributes: {
     get: function() {
       if (!this._attributes) {
@@ -260,6 +293,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type StringElement
+   * @memberof Element.prototype
+   */
   id: {
     get: function() {
       return this.getMetaProperty('id', '');
@@ -269,6 +306,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ArrayElement
+   * @memberof Element.prototype
+   */
   classes: {
     get: function() {
       return this.getMetaProperty('classes', []);
@@ -278,6 +319,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type StringElement
+   * @memberof Element.prototype
+   */
   title: {
     get: function() {
       return this.getMetaProperty('title', '');
@@ -287,6 +332,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type StringElement
+   * @memberof Element.prototype
+   */
   description: {
     get: function() {
       return this.getMetaProperty('description', '');
@@ -296,6 +345,10 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ArrayElement
+   * @memberof Element.prototype
+   */
   links: {
     get: function() {
       return this.getMetaProperty('links', []);
@@ -305,6 +358,11 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ArraySlice
+   * @readonly
+   * @memberof Element.prototype
+   */
   children: {
     get: function() {
       var ArrayElement = require('./array-element');
@@ -327,6 +385,11 @@ var Element = createClass({
     }
   },
 
+  /**
+   * @type ArraySlice
+   * @readonly
+   * @memberof Element.prototype
+   */
   recursiveChildren: {
     get: function() {
       var children = new ArraySlice();

--- a/lib/primitives/member-element.js
+++ b/lib/primitives/member-element.js
@@ -5,6 +5,16 @@ var refract = require('../refraction').refract;
 var Element = require('./element');
 
 
+/**
+ * @class MemberElement
+ *
+ * @param {Element} key
+ * @param {Element} value
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function(key, value, meta, attributes) {
     key = refract(key);
@@ -15,6 +25,10 @@ module.exports = Element.extend({
     this.element = 'member';
   }
 }, {}, {
+  /**
+   * @type Element
+   * @memberof MemberElement.prototype
+   */
   key: {
     get: function() {
       return this.content.key;
@@ -24,6 +38,10 @@ module.exports = Element.extend({
     }
   },
 
+  /**
+   * @type Element
+   * @memberof MemberElement.prototype
+   */
   value: {
     get: function() {
       return this.content.value;

--- a/lib/primitives/null-element.js
+++ b/lib/primitives/null-element.js
@@ -2,6 +2,10 @@
 
 var Element = require('./element');
 
+/**
+ * @class NullElement
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function() {
     Element.apply(this, arguments);

--- a/lib/primitives/number-element.js
+++ b/lib/primitives/number-element.js
@@ -2,6 +2,15 @@
 
 var Element = require('./element');
 
+/**
+ * @class NumberElement
+ *
+ * @param {number} content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function() {
     Element.apply(this, arguments);

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -7,6 +7,15 @@ var ArrayElement = require('./array-element');
 var MemberElement = require('./member-element');
 var ObjectSlice = require('../object-slice');
 
+/**
+ * @class
+ *
+ * @param content
+ * @param meta
+ * @param attributes
+ *
+ * @extends ArrayElement
+ */
 var ObjectElement = ArrayElement.extend({
   constructor: function (content, meta, attributes) {
     var convertedContent = _.keys(content).map(function(key) {
@@ -27,6 +36,10 @@ var ObjectElement = ArrayElement.extend({
     }, {});
   },
 
+  /**
+   * @returns {Element}
+   * @memberof ObjectElement.prototype
+   */
   get: function(name) {
     if (name === undefined) { return undefined; }
 
@@ -39,6 +52,10 @@ var ObjectElement = ArrayElement.extend({
     return member.value;
   },
 
+  /**
+   * @returns {MemberElement}
+   * @memberof ObjectElement.prototype
+   */
   getMember: function(name) {
     if (name === undefined) { return undefined; }
 
@@ -49,6 +66,9 @@ var ObjectElement = ArrayElement.extend({
     );
   },
 
+  /**
+   * @memberof ObjectElement.prototype
+   */
   remove: function (name) {
     var removed = null;
 
@@ -64,6 +84,10 @@ var ObjectElement = ArrayElement.extend({
     return removed;
   },
 
+  /**
+   * @returns {Element}
+   * @memberof ObjectElement.prototype
+   */
   getKey: function(name) {
     var member = this.getMember(name);
 
@@ -74,9 +98,11 @@ var ObjectElement = ArrayElement.extend({
     return undefined;
   },
 
-  /*
+  /**
    * Set allows either a key/value pair to be given or an object
    * If an object is given, each key is set to its respective value
+   *
+   * @memberof ObjectElement.prototype
    */
   set: function(keyOrObject, value) {
     if (_.isObject(keyOrObject)) {
@@ -101,18 +127,28 @@ var ObjectElement = ArrayElement.extend({
     return this;
   },
 
+  /**
+   * @memberof ObjectElement.prototype
+   */
   keys: function() {
     return this.content.map(function(item) {
       return item.key.toValue();
     });
   },
 
+  /**
+   * @memberof ObjectElement.prototype
+   */
   values: function() {
     return this.content.map(function(item) {
       return item.value.toValue();
     });
   },
 
+  /**
+   * @returns {boolean}
+   * @memberof ObjectElement.prototype
+   */
   hasKey: function(value) {
     for (var i = 0; i < this.content.length; i++) {
       if (this.content[i].key.equals(value)) {
@@ -123,26 +159,50 @@ var ObjectElement = ArrayElement.extend({
     return false;
   },
 
+  /**
+   * @returns {array}
+   * @memberof ObjectElement.prototype
+   */
   items: function() {
     return this.content.map(function(item) {
       return [item.key.toValue(), item.value.toValue()];
     });
   },
 
-  map: function(cb) {
+  /**
+   * @param callback
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   *
+   * @memberof ObjectElement.prototype
+   */
+  map: function(callback, thisArg) {
     return this.content.map(function(item) {
-      return cb(item.value, item.key, item);
-    });
+      return callback(item.value, item.key, item);
+    }, thisArg);
   },
 
+  /**
+   * @param callback
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   *
+   * @returns {ObjectSlice}
+   *
+   * @memberof ObjectElement.prototype
+   */
   filter: function(callback, thisArg) {
     return new ObjectSlice(this.content).filter(callback, thisArg);
   },
 
-  forEach: function(cb) {
+  /**
+   * @param callback
+   * @param thisArg - Value to use as this (i.e the reference Object) when executing callback
+   *
+   * @memberof ObjectElement.prototype
+   */
+  forEach: function(callback, thisArg) {
     return this.content.forEach(function(item) {
-      return cb(item.value, item.key, item);
-    });
+      return callback(item.value, item.key, item);
+    }, thisArg);
   }
 });
 

--- a/lib/primitives/string-element.js
+++ b/lib/primitives/string-element.js
@@ -2,6 +2,15 @@
 
 var Element = require('./element');
 
+/**
+ * @class StringElement
+ *
+ * @param {string} content
+ * @param meta
+ * @param attributes
+ *
+ * @extends Element
+ */
 module.exports = Element.extend({
   constructor: function() {
     Element.apply(this, arguments);
@@ -12,6 +21,11 @@ module.exports = Element.extend({
     return 'string';
   }
 }, {}, {
+  /**
+   * @type number
+   * @readonly
+   * @memberof StringElement.prototype
+   */
   length: {
     get: function() {
       return this.content.length;

--- a/lib/refraction.js
+++ b/lib/refraction.js
@@ -1,6 +1,10 @@
 'use strict';
 
-/// Refracts a JSON type to minim elements
+/**
+ * Refracts a JSON type to minim elements
+ * @param value
+ * @returns {Element}
+ */
 function refract(value) {
   var Element = require('./primitives/element');
   var ArrayElement = require('./primitives/array-element');

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -4,11 +4,23 @@ var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
 var KeyValuePair = require('../key-value-pair');
 
+/**
+ * @class JSONSerialiser
+ *
+ * @param {Namespace} namespace
+ *
+ * @property {Namespace} namespace
+ */
 module.exports = createClass({
   constructor: function(namespace) {
     this.namespace = namespace || new Namespace();
   },
 
+  /**
+   * @param {Element} element
+   * @returns {object}
+   * @memberof JSONSerialiser.prototype
+   */
   serialise: function(element) {
     var payload = {
       element: element.element,
@@ -27,6 +39,11 @@ module.exports = createClass({
     return payload;
   },
 
+  /**
+   * @param {object}
+   * @returns {Element}
+   * @memberof JSONSerialiser.prototype
+   */
   deserialise: function(value) {
     if (!value.element) {
       throw new Error('Given value is not an object containing an element name');


### PR DESCRIPTION
This PR adds JSDoc style comments to the public interfaces. I think this can allow us to provide far better documentation that we currently have in the readme and generate a website for all the documentation (minim, minim-api-description, minim-parse-result) eventually. Especially using [sphinx-js](https://hacks.mozilla.org/2017/07/introducing-sphinx-js-a-better-way-to-document-large-javascript-projects/). This pull request is the "first step" which is to add JSDoc comments, they're not perfect and could be iterated on in the future but I think this is a good start.

The jsdoc npm package can be used to generate a website locally, all of the types are hyperlinked.

```shell
$ npm install -g jsdoc
$ jsdoc -r lib
$ open out/index.html
```

Here's just a preview of one method:

![screen shot 2017-08-02 at 16 48 06](https://user-images.githubusercontent.com/44164/28899936-7e2ad86c-77a2-11e7-8d7f-98d171a1e2d6.png)
