### PR TITLE
Allow freezing and placing `parent` properties on elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master
 
+## Breaking
+
 - `Element.children` and `Element.recursiveChildren` now return `ArraySlice`
   instead of an `ArrayElement`.
 - `ArrayElement.filter` and `ArrayElement.find*` now return `ArraySlice`
@@ -8,6 +10,11 @@
   instead of methods.
 - `ObjectElement.filter` now returns an `ObjectSlice` instead of an
   `ObjectElement`.
+
+## Enhancements
+
+- `Element` now contains a `freeze` method to freeze and prevent an element
+  from being mutated, this also adds a parent property on all child elements.
 
 # 0.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   instead of methods.
 - `ObjectElement.filter` now returns an `ObjectSlice` instead of an
   `ObjectElement`.
+- When providing multiple element names to `Element.findRecursive` you must
+  call `freeze` on the element beforehand so that the element has access to the
+  parent of the element.
 
 ## Enhancements
 

--- a/README.md
+++ b/README.md
@@ -207,44 +207,6 @@ that we are recursively looking for all `string` elements that are found within 
 const stringInsideMembers = element.findRecursive('member', 'string');
 ```
 
-##### Parents
-
-Each returned element will include a new `parents` property which is an array
-element including the parents of the returned element.
-
-As an example, if I had an array element which contains a category element
-which in turn contains a string element with the content "Hello World". I can
-access the parent array and category element. The parents are in closest parent
-order.
-
-```json
-{
-  "element": "array",
-  "content": [
-    {
-      "element": "category",
-      "content": [
-        {
-          "element": "string",
-          "content": "Hello World"
-        }
-      ]
-    }
-  ]
-}
-```
-
-```javascript
-const elements = element.findRecursive('string');
-const helloString = elements.first;
-
-// Category Element
-helloString.parents[0];
-
-// Array Element
-helloString.parents[1];
-```
-
 #### children
 
 The `children` property returns an `ArrayElement` containing all of the direct children elements.

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -143,52 +143,38 @@ var Element = createClass({
   },
 
   /**
-   * Finds the given elements in the element tree
+   * Finds the given elements in the element tree.
+   * When providing multiple element names, you must first freeze the element.
+   *
    * @param {...elementNames}
    * @returns {ArraySlice}
    * @memberof Element.prototype
    */
   findRecursive: function() {
-    var ArrayElement = require('./array-element');
-    var elementNames = [].concat.apply([], arguments);
-    var elements = new ArraySlice();
-    var parents;
-
-    if (elementNames[elementNames.length - 1] instanceof ArraySlice) {
-      // clone the given parents
-      parents = new ArraySlice(elementNames.pop().map(function (e) { return e; }));
-    } else {
-      parents = new ArraySlice();
+    if (arguments.length > 1 && !this.isFrozen) {
+      throw new Error('Cannot find recursive with multiple element names without first freezing the element. Call `element.freeze()`');
     }
 
+    var elementNames = [].concat.apply([], arguments);
     var elementName = elementNames.pop();
-
-    parents.unshift(this);
+    var elements = new ArraySlice();
 
     var append = function(array, element) {
       array.push(element);
       return array;
     };
 
-    var attachParents = function(element, parents) {
-      var clonedElement = element.clone();
-      clonedElement.parents = parents;
-      return clonedElement;
-    };
-
     // Checks the given element and appends element/sub-elements
     // that match element name to given array
     var checkElement = function(array, element) {
       if (element.element === elementName) {
-        array.push(attachParents(element, parents));
+        array.push(element);
       }
 
-      var items = element.findRecursive(elementName, parents);
+      var items = element.findRecursive(elementName);
       if (items) {
         items.reduce(append, array);
       }
-
-      parents.unshift(element);
 
       if (element.content instanceof KeyValuePair) {
         if (element.content.key) {
@@ -199,8 +185,6 @@ var Element = createClass({
           checkElement(array, element.content.value);
         }
       }
-
-      parents.shift();
 
       return array;
     };
@@ -228,7 +212,7 @@ var Element = createClass({
           var index = parentElements.indexOf(name);
 
           if (index !== -1) {
-            parentElements.splice(0, index);
+            parentElements = parentElements.splice(0, index);
           } else {
             return false;
           }

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -30,6 +30,36 @@ var Element = createClass({
     this.content = content !== undefined ? content : null;
   },
 
+  /**
+   * Freezes the element to prevent any mutation.
+   * A frozen element will add `parent` property to every child element
+   * to allow traversing up the element tree.
+   *
+   * @memberof Element.prototype
+   */
+  freeze: function() {
+    if (this._meta) {
+      this.meta.parent = this;
+      this.meta.freeze();
+    }
+
+    if (this._attributes) {
+      this.attributes.parent = this;
+      this.attributes.freeze();
+    }
+
+    this.children.forEach(function (element) {
+      element.parent = this;
+      element.freeze();
+    }, this);
+
+    if (this.content && Array.isArray(this.content)) {
+      Object.freeze(this.content);
+    }
+
+    Object.freeze(this);
+  },
+
   primitive: function() {
     return;
   },
@@ -355,6 +385,36 @@ var Element = createClass({
     },
     set: function(element) {
       this.setMetaProperty('links', element);
+    }
+  },
+
+  /**
+   * @type boolean
+   * @readonly
+   * @memberof Element.prototype
+   */
+  isFrozen: {
+    get: function() {
+      return Object.isFrozen(this);
+    }
+  },
+
+  /**
+   * @type ArraySlice
+   * @readonly
+   * @memberof Element.prototype
+   */
+  parents: {
+    get: function() {
+      var parent = this.parent;
+      var parents = new ArraySlice();
+
+      while (parent) {
+        parents.push(parent);
+        parent = parent.parent;
+      }
+
+      return parents;
     }
   },
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -546,28 +546,6 @@ describe('Element', function() {
       expect(result.toValue()).to.deep.equal(['key1', 'value2']);
     });
 
-    it('attaches parent tree to found objects', function () {
-      const StringElement = minim.getElementClass('string');
-      const ArrayElement = minim.getElementClass('array');
-
-      const hello = new StringElement('Hello World')
-      const array = new ArrayElement([hello]);
-      const element = new ArrayElement([array]);
-      array.id = 'Inner';
-      element.id = 'Outter';
-
-      const result = element.findRecursive('string');
-
-      expect(result).to.be.instanceof(ArraySlice);
-      expect(result.toValue()).to.deep.equal(['Hello World']);
-
-      const helloElement = result.get(0);
-      const parentIDs = helloElement.parents.map(function (item) {
-        return item.id.toValue();
-      });
-      expect(parentIDs).to.deep.equal(['Inner', 'Outter']);
-    });
-
     it('finds elements contained in given elements', function () {
       const StringElement = minim.getElementClass('string');
       const ArrayElement = minim.getElementClass('array');
@@ -586,6 +564,8 @@ describe('Element', function() {
         new StringElement('One'),
         object
       ]);
+
+      element.freeze();
 
       const result = element.findRecursive('member', 'array', 'string');
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -55,6 +55,11 @@ describe('Element', function() {
       el = new minim.Element(false);
       expect(el.toValue()).to.equal(false);
     });
+
+    it('should not be frozen', function() {
+      el = new minim.Element('');
+      expect(el.isFrozen).to.be.false;
+    });
   });
 
   describe('#meta', function() {
@@ -624,6 +629,77 @@ describe('Element', function() {
         key: 'name',
         value: 'doe'
       });
+    });
+  });
+
+  describe('freezing an element', function () {
+    it('is frozen after being frozen', function () {
+      var element = new minim.Element('hello');
+      element.freeze();
+
+      expect(element.isFrozen).to.be.true;
+    });
+
+    it('freezes children when freezing', function () {
+      var element = new minim.Element([new minim.elements.String('hello')]);
+      element.freeze();
+
+      expect(element.content[0].isFrozen).to.be.true;
+    });
+
+    it('sets the parent of any children', function () {
+      var element = new minim.Element([new minim.elements.String('hello')]);
+      element.freeze();
+
+      expect(element.content[0].parent).to.equal(element);
+    });
+
+    it('sets the parent of meta elements', function () {
+      var element = new minim.Element();
+      element.title = 'Example';
+      element.freeze();
+
+      expect(element.meta.parent).to.equal(element);
+      expect(element.meta.content[0].parent).to.equal(element.meta);
+    });
+
+    it("doesn't allow modification of content array once frozen", function () {
+      var element = new minim.Element([new minim.elements.String('hello')]);
+      element.freeze();
+
+      expect(function() {
+        element.content.push(new minim.elements.String('hello'));
+      }).to.throw();
+    });
+
+    it("doesn't allow modification of meta once frozen", function () {
+      var element = new minim.Element();
+      element.freeze();
+
+      expect(function() {
+        element.id = 'Hello';
+      }).to.throw();
+    });
+
+    it("doesn't allow modification of attributes once frozen", function () {
+      var element = new minim.Element();
+      element.freeze();
+
+      expect(function() {
+        element.attributes.set('key', 'value');
+      }).to.throw();
+    });
+  });
+
+  describe('#parents', function () {
+    it('configures parent when setting element content to be an element', function () {
+      var one = new minim.Element('bottom');
+      var two = new minim.Element(one);
+      var three = new minim.Element(two);
+      three.freeze();
+
+      expect(one.parents).to.be.instanceof(ArraySlice);
+      expect(one.parents.elements).to.deep.equal([two, three]);
     });
   });
 


### PR DESCRIPTION
This PR adds a new method on Element along with three new properties. You can now call the `freeze` method on an element which will prevent any mutations from happening to the element. Freezing an element will also add a `parent` accessor to all child elements allowing a user to traverse up the element tree.

Without having to support mutation, we can have a much simpler implementation compared to #137. The second commit in this PR will remove the custom parent tracking in findRecursive, since it is needed when you using `findRecursive` with multiple element names it will raise when the element is not frozen.