### PR TITLE
Throw type error when serialising non-element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Master
 
+## Enhancements
+
+- Serialisers will now throw TypeError with straight forward messages when you
+  try to serialise a non-element type.
+
 ## Bug Fixes
 
 - While accessing meta or attributes of a frozen element that does not contain

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -3,6 +3,7 @@
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
 var KeyValuePair = require('../key-value-pair');
+var Element = require('../primitives/element');
 var ArrayElement = require('../primitives/array-element');
 
 module.exports = createClass({
@@ -11,6 +12,10 @@ module.exports = createClass({
   },
 
   serialise: function(element) {
+    if (!(element instanceof Element)) {
+      throw new TypeError('Given element `' + element + '` is not an Element instance');
+    }
+
     var payload = {
       element: element.element,
     };

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -3,6 +3,7 @@
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
 var KeyValuePair = require('../key-value-pair');
+var Element = require('../primitives/element');
 
 /**
  * @class JSONSerialiser
@@ -22,6 +23,10 @@ module.exports = createClass({
    * @memberof JSONSerialiser.prototype
    */
   serialise: function(element) {
+    if (!(element instanceof Element)) {
+      throw new TypeError('Given element `' + element + '` is not an Element instance');
+    }
+
     var payload = {
       element: element.element,
     };

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -24,6 +24,12 @@ describe('JSON Serialiser', function() {
   });
 
   describe('serialisation', function() {
+    it('errors when serialising a non-element', function() {
+      expect(function(){
+        serialiser.serialise('Hello');
+      }).to.throw(TypeError, 'Given element `Hello` is not an Element instance');
+    });
+
     it('serialises a primitive element', function() {
       var element = new minim.elements.String('Hello')
       var object = serialiser.serialise(element);

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -24,6 +24,12 @@ describe('JSON Serialiser', function() {
   });
 
   describe('serialisation', function() {
+    it('errors when serialising a non-element', function() {
+      expect(function(){
+        serialiser.serialise('Hello');
+      }).to.throw(TypeError, 'Given element `Hello` is not an Element instance');
+    });
+
     it('serialises a primitive element', function() {
       var element = new minim.elements.String('Hello')
       var object = serialiser.serialise(element);


### PR DESCRIPTION
When the serialiser is told to serialise an element when the element is not actually an element. We get a cryptic error message because there is no `length` property on an element when we try to check the length later. This makes it a little tricky to debug simple problems and therefore I've made this PR to improve the exception that is raised to make it easier to find the cause of a problem.

### Before

```
TypeError: Cannot read property 'length' of undefined
    at constructor.serialise (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:30:21)
    at Array.map (native)
    at constructor.serialiseContent (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:89:22)
    at constructor.serialise (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:38:31)
    at Array.map (native)
    at constructor.serialiseContent (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:89:22)
    at constructor.serialise (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:38:31)
    at constructor.<anonymous> (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:119:26)
    at Array.forEach (native)
    at constructor.serialiseObject (/Users/kyle/Projects/apiaryio/fury-cli/node_modules/minim/lib/serialisers/json.js:118:16)
```

### After

```
TypeError: Given element `asdf` is not an Element instance
    at constructor.serialise (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:27:13)
    at Array.map (native)
    at constructor.serialiseContent (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:93:22)
    at constructor.serialise (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:42:31)
    at Array.map (native)
    at constructor.serialiseContent (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:93:22)
    at constructor.serialise (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:42:31)
    at constructor.<anonymous> (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:123:26)
    at Array.forEach (native)
    at constructor.serialiseObject (/Users/kyle/Projects/refractproject/minim/lib/serialisers/json.js:122:16)
```