### PR TITLE
Fix some problems when deserialising enum elements in JSON 0.6 serialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
   These accessors will now return an empty frozen `ObjectElement` in these
   cases now to prevent mutation.
+- Fixes JSON 0.6 Deserialiser to correct deserialise enum elements.
+    - When multiple sample values were present additional values were being discarded.
+    - Deserialised enum content contained duplicate enumeration values.
 
 # 0.19.0
 

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -148,8 +148,13 @@ module.exports = createClass({
       element.attributes.remove('samples');
 
       if (samples) {
-        samples = samples.map(function(sample) {
-          return sample.get(0);
+        // Flatten samples array of array
+        var existingSamples = samples;
+        samples = new ArrayElement();
+        existingSamples.forEach(function(sample) {
+          sample.forEach(function (sample) {
+            samples.push(sample);
+          });
         });
 
         var sample = samples.shift();
@@ -161,9 +166,11 @@ module.exports = createClass({
         }
 
         element.attributes.set('samples', samples);
+      } else {
+        element.content = undefined;
       }
 
-      // Unwrap th3e default value
+      // Unwrap the default value
       var defaultValue = element.attributes.get('default');
       if (defaultValue) {
         defaultValue = defaultValue.get(0);

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -556,15 +556,105 @@ describe('JSON Serialiser', function() {
       expect(element.get(0)).to.be.instanceof(minim.elements.Number);
     });
 
-    it('deserialises enum', function() {
-      var enumeration = new minim.Element(new minim.elements.String('South'));
-      enumeration.element = 'enum';
-      enumeration.attributes.set('default', 'North');
-      enumeration.attributes.set('enumerations', ['North', 'East', 'South', 'West']);
-      enumeration.attributes.set('samples', ['North', 'East']);
+    context('enum element', function() {
+      it('deserialises content', function() {
+        var element = serialiser.deserialise({
+          element: 'enum',
+          content: [
+            {
+              element: 'number',
+              content: 3,
+            },
+            {
+              element: 'number',
+              content: 4,
+            },
+          ],
+        });
 
-      var deserializedEnum = serialiser.deserialise(serialiser.serialise(enumeration));
-      expect(minim.toRefract(deserializedEnum)).to.deep.equal(minim.toRefract(enumeration));
+        expect(element.element).to.equal('enum');
+        expect(element.attributes.get('enumerations').toValue()).to.deep.equal([
+          3,
+          4,
+        ]);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialises with sample', function() {
+        var element = serialiser.deserialise({
+          element: 'enum',
+          attributes: {
+            samples: [
+              [
+                {
+                  element: 'number',
+                  content: 3,
+                },
+              ],
+            ],
+          }
+        });
+
+        expect(element.element).to.equal('enum');
+        expect(element.attributes.get('samples').toValue()).to.deep.equal([]);
+        expect(element.toValue()).to.equal(3);
+      });
+
+      it('deserialises with samples', function() {
+        var element = serialiser.deserialise({
+          element: 'enum',
+          attributes: {
+            samples: [
+              [
+                {
+                  element: 'number',
+                  content: 3,
+                },
+                {
+                  element: 'number',
+                  content: 4,
+                },
+              ],
+              [
+                {
+                  element: 'number',
+                  content: 5,
+                },
+                {
+                  element: 'number',
+                  content: 6,
+                },
+              ],
+            ],
+          }
+        });
+
+        expect(element.element).to.equal('enum');
+        expect(element.attributes.get('samples').toValue()).to.deep.equal([
+          4,
+          5,
+          6,
+        ]);
+        expect(element.toValue()).to.equal(3);
+      });
+
+      it('deserialises with default', function() {
+        var element = serialiser.deserialise({
+          element: 'enum',
+          attributes: {
+            default: [
+              {
+                element: 'number',
+                content: 3,
+              },
+            ],
+          }
+        });
+
+        expect(element.element).to.equal('enum');
+        expect(element.attributes.get('default').toValue()).to.equal(3);
+        expect(element.content).to.be.undefined;
+      });
     });
 
     it('deserialises data structure inside an array', function() {


### PR DESCRIPTION
I found two bugs, commented below.

I've also refactored the tests so that there are separate tests for each feature and includes full branch coverage, before since there was a single test for all cases, some if/else cases were not covered.

