### PR TITLE
Don't mutate when calling accessors while frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Master
+
+## Bug Fixes
+
+- While accessing meta or attributes of a frozen element that does not contain
+  meta or attributes, an exception was raised because these accessors would
+  lazy load and attempt to mutate the element.
+
+  These accessors will now return an empty frozen `ObjectElement` in these
+  cases now to prevent mutation.
+
 # 0.19.0
 
 ## Breaking

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -268,6 +268,13 @@ var Element = createClass({
     get: function() {
       if (!this._meta) {
         var ObjectElement = require('./object-element');
+
+        if (this.isFrozen) {
+          var meta = new ObjectElement();
+          meta.freeze();
+          return meta;
+        }
+
         this._meta = new ObjectElement();
       }
 
@@ -292,6 +299,13 @@ var Element = createClass({
     get: function() {
       if (!this._attributes) {
         var ObjectElement = require('./object-element');
+
+        if (this.isFrozen) {
+          var meta = new ObjectElement();
+          meta.freeze();
+          return meta;
+        }
+
         this._attributes = new ObjectElement();
       }
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -669,6 +669,19 @@ describe('Element', function() {
         element.attributes.set('key', 'value');
       }).to.throw();
     });
+
+    it('returns frozen objects from meta/attributes accessors', function () {
+      // An elements meta and attributes are lazy loaded and created on access.
+      // This would cause problems because that means you cannot access
+      // meta/attributes on frozen elements because the accessor has
+      // side-effects of creation.
+
+      var element = new minim.Element();
+      element.freeze();
+
+      expect(element.meta.isFrozen).to.be.true;
+      expect(element.attributes.isFrozen).to.be.true;
+    });
   });
 
   describe('#parents', function () {


### PR DESCRIPTION
Please read the changelog entry in PR to understand the reasons behind this change.

I think we can make it so that meta and attributes are no longer lazy loaded. This would be a larger architecture change to do so and would be breaking so I will not do it during this fix. We will have to discuss this further as meta/attributes couldn't be ObjectElement themselves because then they would have meta/attributes to populate this making the constructor for an element cause an infinite loop.