### PR TITLE
Remove unnecessary use of lodash

### DIFF
--- a/lib/array-slice.js
+++ b/lib/array-slice.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var uptown = require('uptown');
 var refract = require('./refraction').refract;
 var createClass = uptown.createClass;
@@ -73,14 +72,9 @@ var ArraySlice = createClass({
    * @memberof ArraySlice.prototype
    */
   includes: function(value) {
-    for (var i = 0; i < this.length; i++) {
-      var item = this.elements[i];
-      if (_.isEqual(item.toValue(), value)) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.elements.some(function (element) {
+      return element.equals(value);
+    });
   },
 
   // Mutation

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -107,7 +107,7 @@ var ArrayElement = Element.extend({
     var memo;
 
     // Allows for defining a starting value of the reduce
-    if (!_.isUndefined(initialValue)) {
+    if (initialValue !== undefined) {
       startIndex = 0;
       memo = refract(initialValue);
     } else {

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var refract = require('../refraction').refract;
 var Element = require('./element');
 var ArraySlice = require('../array-slice');
@@ -256,14 +255,9 @@ var ArrayElement = Element.extend({
    * @memberof ArrayElement.prototype
    */
   contains: function(value) {
-    for (var i = 0; i < this.content.length; i++) {
-      var item = this.content[i];
-      if (_.isEqual(item.toValue(), value)) {
-        return true;
-      }
-    }
-
-    return false;
+    return this.content.some(function (element) {
+      return element.equals(value);
+    });
   }
 }, {}, {
   /**

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -41,15 +41,13 @@ var ObjectElement = ArrayElement.extend({
    * @memberof ObjectElement.prototype
    */
   get: function(name) {
-    if (name === undefined) { return undefined; }
+    var member = this.getMember(name);
 
-    var member = _.first(
-      this.content.filter(function(item) {
-        return item.key.toValue() === name;
-      })
-    ) || {};
+    if (member) {
+      return member.value;
+    }
 
-    return member.value;
+    return undefined;
   },
 
   /**
@@ -59,11 +57,9 @@ var ObjectElement = ArrayElement.extend({
   getMember: function(name) {
     if (name === undefined) { return undefined; }
 
-    return _.first(
-      this.content.filter(function(item) {
-        return item.key.toValue() === name;
-      })
-    );
+    return this.content.find(function (element) {
+      return element.key.toValue() === name;
+    });
   },
 
   /**

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var expect = require('../spec-helper').expect;
 var minim = require('../../lib/minim').namespace();
 var KeyValuePair = require('../../lib/key-value-pair');
@@ -166,9 +165,9 @@ describe('Element', function() {
     };
 
     context('when the meta is already set', function() {
-      var el = new minim.Element(null, _.clone(meta));
+      var el = new minim.Element(null, meta);
 
-      _.forEach(_.keys(meta), function(key) {
+      Object.keys(meta).forEach(function (key) {
         it('provides a convenience method for ' + key, function() {
           expect(el[key].toValue()).to.deep.equal(meta[key]);
         });
@@ -178,7 +177,7 @@ describe('Element', function() {
     context('when meta is set with getters and setters', function() {
       var el = new minim.Element(null);
 
-      _.forEach(_.keys(meta), function(key) {
+      Object.keys(meta).forEach(function(key) {
         el[key] = meta[key];
 
         it('works for getters and setters for ' + key, function() {

--- a/test/primitives/object-element-test.js
+++ b/test/primitives/object-element-test.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var expect = require('../spec-helper').expect;
 var minim = require('../../lib/minim').namespace();
 
@@ -192,7 +191,7 @@ describe('ObjectElement', function() {
       var keys = [];
       var values = [];
 
-      _.forEach(objectElement.items(), function(item) {
+      objectElement.items().forEach(function(item) {
         var key = item[0];
         var value = item[1];
 


### PR DESCRIPTION
This pull request removes unnecessary use of lodash where the standard library provides the necessary functionality, usually in a simpler way. This simplifies the implementation in some places and provides a performance improvement for `ObjectElement.get*`. Since now `get*` will stop iterating over the entire object when it finds a matching key, the previous implementation would loop over entire set using filter which could result in slower access using `get*` on large elements.