### PR TITLE
Alter content serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- Prevent de-serialising `undefined` if the default element's content is not
+  null.
+
 # 0.20.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Prevent de-serialising `undefined` if the default element's content is not
   null.
+- No longer serialise an empty array in the JSON serialisers, instead the
+  content can be removed for consistency with other tools.
 
 # 0.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.20.1
 
 ## Bug Fixes
 

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -46,7 +46,11 @@ module.exports = createClass({
     if (this[element.element + 'SerialiseContent']) {
       payload['content'] = this[element.element + 'SerialiseContent'](element, payload);
     } else if (element.content !== undefined) {
-      payload['content'] = this.serialiseContent(element.content);
+      var content = this.serialiseContent(element.content);
+
+      if (content !== undefined) {
+        payload['content'] = content;
+      }
     }
 
     return payload;
@@ -219,6 +223,10 @@ module.exports = createClass({
 
       return pair;
     } else if (content && content.map) {
+      if (content.length === 0) {
+        return;
+      }
+
       return content.map(this.serialise, this);
     }
 

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -147,7 +147,7 @@ module.exports = createClass({
     }
 
     var content = this.deserialiseContent(value.content);
-    if (content !== undefined) {
+    if (content !== undefined || element.content === null) {
       element.content = content;
     }
 

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -70,7 +70,7 @@ module.exports = createClass({
     }
 
     var content = this.deserialiseContent(value.content);
-    if (content !== undefined) {
+    if (content !== undefined || element.content === null) {
       element.content = content;
     }
 

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -39,7 +39,11 @@ module.exports = createClass({
       payload['attributes'] = this.serialiseObject(element.attributes);
     }
 
-    payload['content'] = this.serialiseContent(element.content);
+    var content = this.serialiseContent(element.content);
+
+    if (content !== undefined) {
+      payload['content'] = content;
+    }
 
     return payload;
   },
@@ -93,6 +97,10 @@ module.exports = createClass({
 
       return pair;
     } else if (content && content.map) {
+      if (content.length === 0) {
+        return;
+      }
+
       return content.map(this.serialise, this);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -5,7 +5,7 @@ var minim = require('../../lib/minim').namespace();
 var KeyValuePair = require('../../lib/key-value-pair');
 var JSONSerialiser = require('../../lib/serialisers/json-0.6');
 
-describe('JSON Serialiser', function() {
+describe('JSON 0.6 Serialiser', function() {
   var serialiser;
 
   beforeEach(function () {
@@ -533,33 +533,6 @@ describe('JSON Serialiser', function() {
       expect(attribute.content).to.equal('hello');
     });
 
-    it('deserialise string', function() {
-      var element = serialiser.deserialise('Hello');
-
-      expect(element).to.be.instanceof(minim.elements.String);
-      expect(element.content).to.equal('Hello');
-    });
-
-    it('deserialise number', function() {
-      var element = serialiser.deserialise(15);
-
-      expect(element).to.be.instanceof(minim.elements.Number);
-      expect(element.content).to.equal(15);
-    });
-
-    it('deserialise boolean', function() {
-      var element = serialiser.deserialise(true);
-
-      expect(element).to.be.instanceof(minim.elements.Boolean);
-      expect(element.content).to.equal(true);
-    });
-
-    it('deserialise null', function() {
-      var element = serialiser.deserialise(null);
-
-      expect(element).to.be.instanceof(minim.elements.Null);
-    });
-
     it('deserialises an array element from JS array', function() {
       var element = serialiser.deserialise([1]);
 
@@ -778,13 +751,109 @@ describe('JSON Serialiser', function() {
       expect(dataStructure.content).to.be.instanceof(minim.elements.String);
     });
 
-    it('deserialises an object without content', function() {
-      var object = serialiser.deserialise({
-        element: 'object',
+    describe('deserialising base elements', function() {
+      it('deserialise string', function() {
+        var element = serialiser.deserialise({
+          element: 'string',
+          content: 'Hello',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.String);
+        expect(element.content).to.equal('Hello');
       });
 
-      expect(object).to.be.instanceof(minim.elements.Object);
-      expect(object.content).to.deep.equal([]);
+      it('deserialise number', function() {
+        var element = serialiser.deserialise({
+          element: 'number',
+          content: 15,
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Number);
+        expect(element.content).to.equal(15);
+      });
+
+      it('deserialise boolean', function() {
+        var element = serialiser.deserialise({
+          element: 'boolean',
+          content: true
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Boolean);
+        expect(element.content).to.equal(true);
+      });
+
+      it('deserialise null', function() {
+        var element = serialiser.deserialise({
+          element: 'null',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Null);
+      });
+
+      it('deserialise an array', function() {
+        var object = serialiser.deserialise({
+          element: 'array',
+          content: [],
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Array);
+        expect(object.content).to.deep.equal([]);
+      });
+
+      it('deserialise an object', function() {
+        var object = serialiser.deserialise({
+          element: 'object',
+          content: [],
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Object);
+        expect(object.content).to.deep.equal([]);
+      });
+
+      it('deserialise string without content', function() {
+        var element = serialiser.deserialise({
+          element: 'string',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.String);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise number without content', function() {
+        var element = serialiser.deserialise({
+          element: 'number',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Number);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise boolean without content', function() {
+        var element = serialiser.deserialise({
+          element: 'boolean',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Boolean);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise an array', function() {
+        var object = serialiser.deserialise({
+          element: 'array',
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Array);
+        expect(object.content).to.deep.equal([]);
+      });
+
+      it('deserialise an object without content', function() {
+        var object = serialiser.deserialise({
+          element: 'object',
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Object);
+        expect(object.content).to.deep.equal([]);
+      });
     });
   });
 });

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -73,6 +73,16 @@ describe('JSON 0.6 Serialiser', function() {
       });
     });
 
+    it('serialises an element containing an empty array', function() {
+      var element = new minim.elements.Array();
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'array',
+      });
+    });
+
     it('serialise an element with object content', function() {
       var element = new minim.elements.Element({ message: 'hello' });
       var object = serialiser.serialise(element);

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -73,6 +73,17 @@ describe('JSON Serialiser', function() {
       });
     });
 
+    it('serialises an element containing an empty array', function() {
+      var element = new minim.elements.Array();
+
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'array',
+      });
+    });
+
+
     it('serialise an element with object content', function() {
       var element = new minim.elements.Element({ message: 'hello' });
       var object = serialiser.serialise(element);

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -296,51 +296,109 @@ describe('JSON Serialiser', function() {
       expect(attribute.content).to.equal('hello');
     });
 
-    it('deserialise string', function() {
-      var element = serialiser.deserialise({
-        element: 'string',
-        content: 'Hello',
+    describe('deserialising base elements', function() {
+      it('deserialise string', function() {
+        var element = serialiser.deserialise({
+          element: 'string',
+          content: 'Hello',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.String);
+        expect(element.content).to.equal('Hello');
       });
 
-      expect(element).to.be.instanceof(minim.elements.String);
-      expect(element.content).to.equal('Hello');
-    });
+      it('deserialise number', function() {
+        var element = serialiser.deserialise({
+          element: 'number',
+          content: 15,
+        });
 
-    it('deserialise number', function() {
-      var element = serialiser.deserialise({
-        element: 'number',
-        content: 15,
+        expect(element).to.be.instanceof(minim.elements.Number);
+        expect(element.content).to.equal(15);
       });
 
-      expect(element).to.be.instanceof(minim.elements.Number);
-      expect(element.content).to.equal(15);
-    });
+      it('deserialise boolean', function() {
+        var element = serialiser.deserialise({
+          element: 'boolean',
+          content: true
+        });
 
-    it('deserialise boolean', function() {
-      var element = serialiser.deserialise({
-        element: 'boolean',
-        content: true
+        expect(element).to.be.instanceof(minim.elements.Boolean);
+        expect(element.content).to.equal(true);
       });
 
-      expect(element).to.be.instanceof(minim.elements.Boolean);
-      expect(element.content).to.equal(true);
-    });
+      it('deserialise null', function() {
+        var element = serialiser.deserialise({
+          element: 'null',
+        });
 
-    it('deserialise null', function() {
-      var element = serialiser.deserialise({
-        element: 'null',
+        expect(element).to.be.instanceof(minim.elements.Null);
       });
 
-      expect(element).to.be.instanceof(minim.elements.Null);
-    });
+      it('deserialise an array', function() {
+        var object = serialiser.deserialise({
+          element: 'array',
+          content: [],
+        });
 
-    it('deserialises an object without content', function() {
-      var object = serialiser.deserialise({
-        element: 'object',
+        expect(object).to.be.instanceof(minim.elements.Array);
+        expect(object.content).to.deep.equal([]);
       });
 
-      expect(object).to.be.instanceof(minim.elements.Object);
-      expect(object.content).to.deep.equal([]);
+      it('deserialise an object', function() {
+        var object = serialiser.deserialise({
+          element: 'object',
+          content: [],
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Object);
+        expect(object.content).to.deep.equal([]);
+      });
+
+      it('deserialise string without content', function() {
+        var element = serialiser.deserialise({
+          element: 'string',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.String);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise number without content', function() {
+        var element = serialiser.deserialise({
+          element: 'number',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Number);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise boolean without content', function() {
+        var element = serialiser.deserialise({
+          element: 'boolean',
+        });
+
+        expect(element).to.be.instanceof(minim.elements.Boolean);
+        expect(element.content).to.be.undefined;
+      });
+
+      it('deserialise an array', function() {
+        var object = serialiser.deserialise({
+          element: 'array',
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Array);
+        expect(object.content).to.deep.equal([]);
+      });
+
+      it('deserialise an object without content', function() {
+        var object = serialiser.deserialise({
+          element: 'object',
+        });
+
+        expect(object).to.be.instanceof(minim.elements.Object);
+        expect(object.content).to.deep.equal([]);
+      });
     });
   });
 });


### PR DESCRIPTION
## Bug Fixes

- Prevent de-serialising `undefined` if the default element's content is not null. So we don't replace an arrays content with undefined.
- No longer serialise an empty array in the JSON serialisers, instead the content can be removed for consistency with other tools.