### PR TITLE
Serialise empty arrays in 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Master
+# 0.20.2
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Master
+
+## Bug Fixes
+
+- The JSON 0.6 serialiser will now serialise empty content arrays. A regression
+  caused in 0.20.1 because of the logic was applied to both Refract JSON 1.0
+  and 0.6 serialisers.
+
 # 0.20.1
 
 ## Bug Fixes

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -223,10 +223,6 @@ module.exports = createClass({
 
       return pair;
     } else if (content && content.map) {
-      if (content.length === 0) {
-        return;
-      }
-
       return content.map(this.serialise, this);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -80,6 +80,7 @@ describe('JSON 0.6 Serialiser', function() {
 
       expect(object).to.deep.equal({
         element: 'array',
+        content: []
       });
     });
 


### PR DESCRIPTION
The JSON 0.6 serialiser will now serialise empty content arrays. A regression caused in 0.20.1 because of the logic was applied to both Refract JSON 1.0 and 0.6 serialisers.