### PR TITLE
Uptown goes 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "lodash": "^4.15.0",
-    "uptown": "^0.4.1"
+    "uptown": "^1.0.1"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Minim is now _production ready_ at 1.0.0. It's been ready for some time, but we made some changes to add browser distribution and bumped to version 1.0  