### PR TITLE
Provide browser distribution in dist/minim.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
+
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Master
+
+## Enhancements
+
+- Minim NPM package now contains a browser distribution in `dist/minim.js`.
+
 # 0.20.2
 
 ## Bug Fixes

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {
+    "prepare": "npm run build",
+    "build": "browserify -d -s minim -x lodash -o dist/minim.js lib/minim.js",
     "coverage": "istanbul cover _mocha -- -R spec --recursive",
     "coveralls": "coveralls <coverage/lcov.info",
     "frontendtests": "karma start",


### PR DESCRIPTION
This uses browserify which is already a dev dependency to provide a browser distribution on minim which can be used directly from CDNs such as unpkg.com.  