### PR TITLE
Don't create meta/attributes when checking if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Enhancements
 
 - Minim NPM package now contains a browser distribution in `dist/minim.js`.
+- Performance improvements have been made to JSON Serialisation. The serialiser
+  can now serialise deep structures a little faster.
 
 # 0.20.2
 

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -20,17 +20,17 @@ module.exports = createClass({
       element: element.element,
     };
 
-    if (element.meta.length > 0) {
+    if (element._meta && element._meta.length > 0) {
       payload['meta'] = this.serialiseObject(element.meta);
     }
 
-    if (this[element.element + 'SerialiseAttributes']) {
-      var attributes = this[element.element + 'SerialiseAttributes'](element);
+    if (element.element === 'enum') {
+      var attributes = this.enumSerialiseAttributes(element);
 
       if (attributes) {
         payload['attributes'] = attributes;
       }
-    } else if (element.attributes.length > 0) {
+    } else if (element._attributes && element._attributes.length > 0) {
       var attributes = element.attributes;
 
       // Meta attribute was renamed to metadata
@@ -111,11 +111,15 @@ module.exports = createClass({
     // In API Elements < 1.0, the content is the enumerations
     // If we don't have an enumerations, use the value (Drafter 3 behaviour)
 
-    var enumerations = element.attributes.get('enumerations');
+    if (element._attributes) {
+      var enumerations = element.attributes.get('enumerations');
 
-    if (enumerations && enumerations.length > 0) {
-      return enumerations.content.map(this.serialise, this);
-    } else if (element.content) {
+      if (enumerations && enumerations.length > 0) {
+        return enumerations.content.map(this.serialise, this);
+      }
+    }
+
+    if (element.content) {
       return [this.serialise(element.content)];
     }
 
@@ -250,7 +254,7 @@ module.exports = createClass({
   },
 
   shouldRefract: function (element) {
-    if (element.attributes.keys().length || element.meta.keys().length) {
+    if ((element._attributes && element.attributes.keys().length) || (element._meta && element.meta.keys().length)) {
       return true;
     }
 

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -31,11 +31,11 @@ module.exports = createClass({
       element: element.element,
     };
 
-    if (element.meta.length > 0) {
+    if (element._meta && element._meta.length > 0) {
       payload['meta'] = this.serialiseObject(element.meta);
     }
 
-    if (element.attributes.length > 0) {
+    if (element._attributes && element._attributes.length > 0) {
       payload['attributes'] = this.serialiseObject(element.attributes);
     }
 


### PR DESCRIPTION
The `meta` and `attributes` properties of an element are computed, in the case that meta and attributes are not set when access. An empty `ObjectElement` is returned.

When we check if meta or attributes is empty, if we access via the getter there may be an unnecessary instantiation of an `ObjectElement` which slows down serialisation when meta or attributes is not set.