### PR TITLE
Lazy load elements only once during the refraction function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Enhancements
+
+- Further performance improvements have been made to JSON Serialisation. The
+  serialiser can now deserialise deep structures substantially faster.
+
 # 0.20.3
 
 ## Enhancements

--- a/lib/refraction.js
+++ b/lib/refraction.js
@@ -1,18 +1,34 @@
 'use strict';
 
+var Element;
+var StringElement;
+var MemberElement;
+var NumberElement;
+var BooleanElement;
+var NullElement;
+var ArrayElement;
+var ObjectElement;
+
+function load() {
+  Element = require('./primitives/element');
+  StringElement = require('./primitives/string-element');
+  NumberElement = require('./primitives/number-element');
+  BooleanElement = require('./primitives/boolean-element');
+  NullElement = require('./primitives/null-element');
+  ArrayElement = require('./primitives/array-element');
+  ObjectElement = require('./primitives/object-element');
+}
+
 /**
  * Refracts a JSON type to minim elements
  * @param value
  * @returns {Element}
  */
 function refract(value) {
-  var Element = require('./primitives/element');
-  var ArrayElement = require('./primitives/array-element');
-  var NumberElement = require('./primitives/number-element');
-  var StringElement = require('./primitives/string-element');
-  var BooleanElement = require('./primitives/boolean-element');
-  var NullElement = require('./primitives/null-element');
-  var ObjectElement = require('./primitives/object-element');
+  if (!Element) {
+    // Lazy load all of the elements
+    load();
+  }
 
   if (value instanceof Element) {
     return value;


### PR DESCRIPTION
This has a substantial performance improvement to deserialisation and ArrayElement and ObjectElement creation as these code paths can call `refract` multiple times and Element source are loaded dozens of times.

Before:

```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (552ms)
    ✓ large deserialisation test (1773ms)


  2 passing (2s)
```

After:

```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (188ms)
    ✓ large deserialisation test (584ms)


  2 passing (779ms)
```