### PR TITLE
Cache ObjectElement import from Element

### DIFF
--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -6,6 +6,15 @@ var createClass = uptown.createClass;
 var KeyValuePair = require('../key-value-pair');
 var ArraySlice = require('../array-slice.js');
 
+var ObjectElement;
+
+
+function loadObjectElement() {
+  if (!ObjectElement) {
+    ObjectElement = require('./object-element');
+  }
+}
+
 /**
  * @class
  *
@@ -274,7 +283,7 @@ var Element = createClass({
   meta: {
     get: function() {
       if (!this._meta) {
-        var ObjectElement = require('./object-element');
+        loadObjectElement();
 
         if (this.isFrozen) {
           var meta = new ObjectElement();
@@ -288,7 +297,7 @@ var Element = createClass({
       return this._meta;
     },
     set: function(value) {
-      var ObjectElement = require('./object-element');
+      loadObjectElement();
 
       if (value instanceof ObjectElement) {
         this._meta = value;
@@ -305,7 +314,7 @@ var Element = createClass({
   attributes: {
     get: function() {
       if (!this._attributes) {
-        var ObjectElement = require('./object-element');
+        loadObjectElement();
 
         if (this.isFrozen) {
           var meta = new ObjectElement();
@@ -319,7 +328,8 @@ var Element = createClass({
       return this._attributes;
     },
     set: function(value) {
-      var ObjectElement = require('./object-element');
+      loadObjectElement();
+
       if (value instanceof ObjectElement) {
         this._attributes = value;
       } else {


### PR DESCRIPTION
Yet again, another decent performance improvement

Before:

```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (206ms)
    ✓ large deserialisation test (581ms)


  2 passing (799ms)
```


After

```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (53ms)
    ✓ large deserialisation test (410ms)


  2 passing (470ms)
```