### PR TITLE
Cache elements property of namespace

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -97,6 +97,7 @@ var Namespace = createClass({
    * @memberof Namespace.prototype
    */
   register: function(name, ElementClass) {
+    this._elements = undefined;
     this.elementMap[name] = ElementClass;
     return this;
   },
@@ -109,6 +110,7 @@ var Namespace = createClass({
    * @memberof Namespace.prototype
    */
   unregister: function(name) {
+    this._elements = undefined;
     delete this.elementMap[name];
     return this;
   },
@@ -190,20 +192,22 @@ var Namespace = createClass({
    */
   elements: {
     get: function() {
-      var name, pascal;
-      var elements = {
-        Element: this.Element
-      };
+      if (this._elements === undefined) {
+        var name, pascal;
+        this._elements = {
+          Element: this.Element
+        };
 
-      for (name in this.elementMap) {
-        // Currently, all registered element types use a camelCaseName.
-        // Converting to PascalCase is as simple as upper-casing the first
-        // letter.
-        pascal = name[0].toUpperCase() + name.substr(1);
-        elements[pascal] = this.elementMap[name];
+        for (name in this.elementMap) {
+          // Currently, all registered element types use a camelCaseName.
+          // Converting to PascalCase is as simple as upper-casing the first
+          // letter.
+          pascal = name[0].toUpperCase() + name.substr(1);
+          this._elements[pascal] = this.elementMap[name];
+        }
       }
 
-      return elements;
+      return this._elements;
     }
   },
 


### PR DESCRIPTION
Re-computing on every call is expensive, we can cache on access and clear cache when the underlying data is changed (when element is registered or unregistered). Gains around 25% performance improvement with a large deserialisation.

Before

```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (66ms)
    ✓ large deserialisation test (408ms)


  2 passing (481ms)
```

After
  
```
$ ./node_modules/.bin/mocha tests.js


  Performance Test
    ✓ creation of dozens of elements (54ms)
    ✓ large deserialisation test (314ms)


  2 passing (376ms)
```