### PR TITLE
fix: Serialise enum with content to 0.6 correctly

### DIFF
--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -120,7 +120,7 @@ module.exports = createClass({
     }
 
     if (element.content) {
-      return [this.serialise(element.content)];
+      return this.serialiseContent(element.content);
     }
 
     return [];

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -3,13 +3,13 @@ var expect = require('../spec-helper').expect;
 var Namespace = require('../../lib/minim').Namespace;
 var minim = require('../../lib/minim').namespace();
 var KeyValuePair = require('../../lib/key-value-pair');
-var JSONSerialiser = require('../../lib/serialisers/json-0.6');
+var JSON06Serialiser = require('../../lib/serialisers/json-0.6');
 
 describe('JSON 0.6 Serialiser', function() {
   var serialiser;
 
   beforeEach(function () {
-    serialiser = new JSONSerialiser(minim);
+    serialiser = new JSON06Serialiser(minim);
   });
 
   describe('initialisation', function() {
@@ -18,7 +18,7 @@ describe('JSON 0.6 Serialiser', function() {
     });
 
     it('creates a default namespace when no namespace is given', function() {
-      serialiser = new JSONSerialiser();
+      serialiser = new JSON06Serialiser();
       expect(serialiser.namespace).to.be.instanceof(Namespace);
     });
   });
@@ -280,6 +280,40 @@ describe('JSON 0.6 Serialiser', function() {
           {
             element: 'string',
             content: 'West',
+          },
+        ],
+      });
+    });
+
+    it('serialises enum with content', function () {
+      var enumeration = new minim.Element();
+      enumeration.element = 'enum';
+      enumeration.attributes.set('enumerations', []);
+      enumeration.content = [new minim.elements.String(null)];
+
+      var object = serialiser.serialise(enumeration);
+
+      expect(object).to.deep.equal({
+        element: 'enum',
+        attributes: {
+          samples: [
+            [
+              {
+                element: 'array',
+                content: [
+                  {
+                    element: 'string',
+                    content: null,
+                  },
+                ],
+              },
+            ],
+          ],
+        },
+        content: [
+          {
+            element: 'string',
+            content: null,
           },
         ],
       });


### PR DESCRIPTION
I am not terribly sure the fix is correct here. The document which is responsible for crashing is:

```
swagger: '2.0'
info:
  title: Crash
  version: 1
paths:
  /:
    get:
      parameters:
        - name: interests
          type: array
          items:
            type: string
          enum:
            - Homeless
          in: query  
          description: Interest
      responses:
        '401':
          description: Unauthorised
```

You could reproduce the crash by doing the following:

```
fury crash.yaml -f 'application/vnd.refract.parse-result+json; version=0.6'
```
