### PR TITLE
Use correct array returns syntax

### DIFF
--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -198,7 +198,7 @@ var ArrayElement = Element.extend({
 
   /**
    * Recusively search all descendents using a condition function.
-   * @returns {array[Element]}
+   * @returns {Element[]}
    * @memberof ArrayElement.prototype
    */
   findElements: function(condition, givenOptions) {


### PR DESCRIPTION
`Array[Element]` contains invalid characters and thus results in JSDoc error during invocation.

```
$ ./node_modules/.bin/jsdoc -r lib
ERROR: Unable to parse a tag's type expression for source file /Users/kyle/Projects/refractproject/minim/lib/primitives/array-element.js in line 199 with tag title "returns" and text "{Array[Element]}": Invalid type expression "Array[Element]": Expected "!", "#", "$", "(", "-", ".", "/", "0", ":", "<", "=", "?", "@", "[]", "\\", "\u200C", "\u200D", "_", "|", "~", Unicode combining mark, Unicode decimal number, Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode punctuation connector, Unicode titlecase letter, Unicode uppercase letter, [1-9] or end of input but "[" found.
ERROR: Unable to parse a tag's type expression for source file /Users/kyle/Projects/refractproject/minim/lib/primitives/array-element.js in line 204 with tag title "returns" and text "{Array[Element]}": Invalid type expression "Array[Element]": Expected "!", "#", "$", "(", "-", ".", "/", "0", ":", "<", "=", "?", "@", "[]", "\\", "\u200C", "\u200D", "_", "|", "~", Unicode combining mark, Unicode decimal number, Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode punctuation connector, Unicode titlecase letter, Unicode uppercase letter, [1-9] or end of input but "[" found.
```