### PR TITLE
Strip fixed typeAttribute for enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Master
 
+## Bug Fixes
+
+- JSON 0.6 enum serialisation will now remove `fixed` typeAttributes which are
+  now present in API Elements 1.0 enumerations. These are removed for
+  consistent serialisation of the 0.6 serialiser.
+
 ## 0.20.4
 
 - Further performance improvements have been made to JSON Serialisation. The

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -82,10 +82,14 @@ module.exports = createClass({
     // Wrap default in array
     var defaultValue = attributes.get('default');
     if (defaultValue && defaultValue.content) {
+      defaultValue.content.attributes.remove('typeAttributes');
       attributes.set('default', new ArrayElement([defaultValue.content]));
     }
 
     var samples = attributes.get('samples') || new ArrayElement([]);
+    samples.forEach(function (sample) {
+      sample.content.attributes.remove('typeAttributes');
+    });
 
     // Content -> Samples
     if (element.content && enumerations.length !== 0) {
@@ -115,12 +119,18 @@ module.exports = createClass({
       var enumerations = element.attributes.get('enumerations');
 
       if (enumerations && enumerations.length > 0) {
-        return enumerations.content.map(this.serialise, this);
+        return enumerations.content.map(function (enumeration) {
+          var element = enumeration.clone();
+          element.attributes.remove('typeAttributes');
+          return this.serialise(element);
+        }, this);
       }
     }
 
     if (element.content) {
-      return [this.serialise(element.content)];
+      var value = element.content.clone();
+      value.attributes.remove('typeAttributes');
+      return [this.serialise(value)];
     }
 
     return [];

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -185,7 +185,7 @@ describe('JSON 0.6 Serialiser', function() {
 
     it('serialises enum', function() {
       var defaultElement = new minim.Element(new minim.elements.String('North'));
-      defaultElement.element = 'default';
+      defaultElement.element = 'enum';
 
       var sampleNorth = new minim.Element(new minim.elements.String('North'));
       sampleNorth.element = 'enum';
@@ -250,6 +250,106 @@ describe('JSON 0.6 Serialiser', function() {
           {
             element: 'string',
             content: 'West',
+          },
+        ],
+      });
+    });
+
+    it('serialises enum with fixed values', function() {
+      var defaultElement = new minim.Element(new minim.elements.String('North'));
+      defaultElement.element = 'enum';
+      defaultElement.content.attributes.set('typeAttributes', ['fixed']);
+
+      var sampleNorth = new minim.Element(new minim.elements.String('North'));
+      sampleNorth.element = 'enum';
+      var sampleEast = new minim.Element(new minim.elements.String('East'));
+      sampleEast.element = 'enum';
+      var samples = new minim.elements.Array([
+        sampleNorth,
+        sampleEast,
+      ]);
+
+      sampleNorth.content.attributes.set('typeAttributes', ['fixed']);
+      sampleEast.content.attributes.set('typeAttributes', ['fixed']);
+
+      var enumeration = new minim.Element(new minim.elements.String('South'));
+      enumeration.element = 'enum';
+      enumeration.attributes.set('default', defaultElement);
+      enumeration.attributes.set('enumerations', ['North', 'East', 'South', 'West']);
+      enumeration.attributes.set('samples', samples);
+
+      const enumerations = enumeration.attributes.get('enumerations');
+      enumerations.get(0).attributes.set('typeAttributes', ['fixed']);
+      enumerations.get(1).attributes.set('typeAttributes', ['fixed']);
+      enumerations.get(2).attributes.set('typeAttributes', ['fixed']);
+      enumerations.get(3).attributes.set('typeAttributes', ['fixed']);
+
+      var object = serialiser.serialise(enumeration);
+
+      expect(object).to.deep.equal({
+        element: 'enum',
+        attributes: {
+          default: [
+            {
+              element: 'string',
+              content: 'North',
+            },
+          ],
+          samples: [
+            [
+              {
+                element: 'string',
+                content: 'South',
+              }
+            ],
+            [
+              {
+                element: 'string',
+                content: 'North'
+              }
+            ],
+            [
+              {
+                element:'string',
+                content: 'East'
+              }
+            ]
+          ],
+        },
+        content: [
+          {
+            element: 'string',
+            content: 'North',
+          },
+          {
+            element: 'string',
+            content: 'East',
+          },
+          {
+            element: 'string',
+            content: 'South',
+          },
+          {
+            element: 'string',
+            content: 'West',
+          },
+        ],
+      });
+    });
+
+    it('serialises enum with fixed content', function() {
+      var enumeration = new minim.Element(new minim.elements.String('South'));
+      enumeration.element = 'enum';
+      enumeration.content.attributes.set('typeAttributes', ['fixed']);
+
+      var object = serialiser.serialise(enumeration);
+
+      expect(object).to.deep.equal({
+        element: 'enum',
+        content: [
+          {
+            element: 'string',
+            content: 'South',
           },
         ],
       });


### PR DESCRIPTION
The `fixed` typeAttribute was never used in enumerations in existing JSON 0.6 and is introduced in newer enum element found in API Elements 1.0.