### PR TITLE
ArraySlice.flatMap and ArraySlice.reduce test cases

### DIFF
--- a/lib/array-slice.js
+++ b/lib/array-slice.js
@@ -73,7 +73,9 @@ var ArraySlice = createClass({
     this.forEach(function (element) {
       var result = callback(element);
 
-      if (result) {
+      if (Array.isArray(result)) {
+        results.push.apply(results, result);
+      } else if (result) {
         results.push(result);
       }
     }, thisArg);

--- a/test/array-slice-test.js
+++ b/test/array-slice-test.js
@@ -214,6 +214,53 @@ describe('ArraySlice', function () {
     expect(flattened).to.deep.equal([0, 1, 2, 3, 4, 5]);
   });
 
+  /**
+   * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Alternative
+   */
+  it('provides flatMap as an alternative to reduce', function () {
+    var arr1 = new ArraySlice([1, 2, 3, 4]);
+
+    var reduced = arr1.reduce(
+      function (acc, x) {
+        return acc.concat([x * 2]);
+      },
+      []
+    );
+
+    expect(reduced).to.deep.equal([2, 4, 6, 8]);
+
+    var flattened = arr1.flatMap(function (x) {
+      return [x * 2];
+    });
+
+    expect(flattened).to.deep.equal(reduced);
+  });
+
+  /**
+   * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Examples
+   */
+  it('provides flatMap to flatten one level', function () {
+    var arr1 = new ArraySlice([1, 2, 3, 4]);
+
+    var mapped = arr1.map(function (x) {
+      return [x * 2];
+    });
+
+    expect(mapped).to.deep.equal([[2], [4], [6], [8]]);
+
+    var flattened = arr1.flatMap(function (x) {
+      return [x * 2];
+    });
+
+    expect(flattened).to.deep.equal([2, 4, 6, 8]);
+
+    var flattenOnce = arr1.flatMap(function (x) {
+      return [[x * 2]];
+    });
+
+    expect(flattenOnce).to.deep.equal([[2], [4], [6], [8]]);
+  });
+
   describe('#includes', function () {
     var slice = new ArraySlice([
       new Element('one'),

--- a/test/array-slice-test.js
+++ b/test/array-slice-test.js
@@ -185,6 +185,35 @@ describe('ArraySlice', function () {
     expect(indexes).to.deep.equal([0, 1]);
   });
 
+  /**
+   * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Examples
+   */
+  it('provides reduce to sum all the values of an array', function () {
+    var slice = new ArraySlice([0, 1, 2, 3]);
+
+    var sum = slice.reduce(function (accumulator, currentValue) {
+      return accumulator + currentValue;
+    }, 0);
+
+    expect(sum).to.equal(6);
+  });
+
+  /**
+   * @link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Examples
+   */
+  it('provides reduce to flatten an array of arrays', function () {
+    var slice = new ArraySlice([[0, 1], [2, 3], [4, 5]]);
+
+    var flattened = slice.reduce(
+      function(accumulator, currentValue) {
+        return accumulator.concat(currentValue);
+      },
+      []
+    );
+
+    expect(flattened).to.deep.equal([0, 1, 2, 3, 4, 5]);
+  });
+
   describe('#includes', function () {
     var slice = new ArraySlice([
       new Element('one'),


### PR DESCRIPTION
Adds ArraySlice test cases copied from [Array.reduce](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Examples) and [Array.flatMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Examples).

ArraySlice.flatMap had to be adjusted slightly to flatten an array of arrays, per Mozilla's test cases. That change is compatible with the existing ArraySlice.flatMap test. Are we OK with that difference in behavior between ArraySlice.flatMap and Array.flatMap? Is aligning with Array.flatMap desirable?