### PR TITLE
feat: provide isMinim for ducktyping

### DIFF
--- a/lib/array-slice.js
+++ b/lib/array-slice.js
@@ -39,6 +39,12 @@ var ArraySlice = createClass({
   },
 
   /**
+   * Ducktyping support (to avoid using instanceof)
+   * @memberof ArraySlice.prototype
+   */
+  isMinim: true,
+
+  /**
    * @returns {Array}
    * @memberof ArraySlice.prototype
    */

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -40,6 +40,12 @@ var Element = createClass({
   },
 
   /**
+   * Ducktyping support (to avoid using instanceof)
+   * @memberof Element.prototype
+   */
+  isMinim: true,
+
+  /**
    * Freezes the element to prevent any mutation.
    * A frozen element will add `parent` property to every child element
    * to allow traversing up the element tree.

--- a/test/array-slice-test.js
+++ b/test/array-slice-test.js
@@ -5,6 +5,12 @@ var StringElement = minim.StringElement;
 var ArraySlice = minim.ArraySlice;
 
 describe('ArraySlice', function () {
+  it('supports isMinim ducktyping check', function () {
+    var slice = new ArraySlice([new Element()]);
+
+    expect(slice.isMinim).to.be.true;
+  });
+
   it('can be created from an array of elements', function () {
     var element = new Element();
     var slice = new ArraySlice([element]);

--- a/test/primitives/array-element-test.js
+++ b/test/primitives/array-element-test.js
@@ -5,6 +5,14 @@ var minim = require('../../lib/minim').namespace();
 var ArrayElement = minim.getElementClass('array');
 
 describe('ArrayElement', function() {
+  context('ducktyping', function () {
+    it('has isMinim: true property', function () {
+      const arrayElement = new ArrayElement([]);
+
+      expect(arrayElement.isMinim).to.be.true;
+    });
+  });
+
   context('value methods', function() {
     var arrayElement;
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -189,6 +189,14 @@ describe('Element', function() {
         });
       });
     });
+
+    context('ducktyping', function() {
+      var el = new minim.Element(null);
+
+      it('has isMinim: true property', function () {
+        expect(el.isMinim).to.be.true;
+      });
+    });
   });
 
   describe('removing meta properties', function() {


### PR DESCRIPTION
Would help [here](https://github.com/refractproject/minim-api-description/issues/38) to create a generic `element` predicate while avoiding the use of the generally discouraged `instanceof` operator.