### PR TITLE
Deserialise meta into metadata in 0.6 deserialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Master
+
+## Bug Fixes
+
+- JSON 0.6 deserialiser will now correct deserialise an API Categories `meta`
+  attribute into `metadata`.
+
 # 0.20.5
 
 ## Bug Fixes

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -216,6 +216,21 @@ module.exports = createClass({
       }
     } else if (element.element === 'dataStructure' && Array.isArray(element.content)) {
       element.content = element.content[0];
+    } else if (element.element === 'category') {
+      // "meta" attribute has been renamed to metadata
+      var metadata = element.attributes.get('meta');
+
+      if (metadata) {
+        if (metadata.element === 'array') {
+          // "meta" was deserialised as array
+          var content = metadata.content;
+          metadata = new this.namespace.elements.Object();
+          metadata.content = content;
+        }
+
+        element.attributes.set('metadata', metadata);
+        element.attributes.remove('meta');
+      }
     }
 
     return element;

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -862,6 +862,35 @@ describe('JSON 0.6 Serialiser', function() {
       expect(dataStructure.content).to.be.instanceof(minim.elements.String);
     });
 
+    it('deserialises category with meta attribute', function() {
+      var category = serialiser.deserialise({
+        element: 'category',
+        attributes: {
+          meta: [
+            {
+              element: 'member',
+              meta: {
+                classes: ['user']
+              },
+              content: {
+                key: 'HOST',
+                value: 'https://example.com'
+              }
+            }
+          ]
+        },
+        content: []
+      });
+
+      var metadata = category.attributes.get('metadata');
+      expect(metadata).to.be.instanceof(minim.elements.Object);
+
+      var member = metadata.getMember('HOST');
+      expect(member).to.be.instanceof(minim.elements.Member);
+      expect(member.classes.toValue()).to.deep.equal(['user']);
+      expect(member.value.toValue()).to.equal('https://example.com');
+    });
+
     describe('deserialising base elements', function() {
       it('deserialise string', function() {
         var element = serialiser.deserialise({


### PR DESCRIPTION
This fixes the bug that is worked around in https://github.com/apiaryio/Paw-APIBlueprintImporter/blob/568d73e44bdff23495c24fb3f4b5cd2d1cc8025a/src/APIElementImporter.js#L8 and is also causing documentation team problems.

Meta will be correct deserialised in 0.6 as metadata as an object element with this fix.