### PR TITLE
Use namespace for all element lookups during serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-# Master
+# 0.20.6
 
 ## Bug Fixes
 
 - JSON 0.6 deserialiser will now correct deserialise an API Categories `meta`
   attribute into `metadata`.
+
+- JSON Serialisers will now use elements from the given namespace during
+  serialisation checks and deserialisation.
 
 # 0.20.5
 

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -19,6 +19,7 @@ var Namespace = createClass({
     this.elementMap = {};
     this.elementDetection = [];
     this.Element = require('./primitives/element');
+    this.KeyValuePair = require('./key-value-pair');
 
     if (!options || !options.noDefault) {
       this.useDefault();

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -2,7 +2,6 @@
 
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
-var KeyValuePair = require('../key-value-pair');
 
 module.exports = createClass({
   constructor: function(namespace) {
@@ -239,7 +238,7 @@ module.exports = createClass({
   serialiseContent: function(content) {
     if (content instanceof this.namespace.elements.Element) {
       return this.serialise(content);
-    } else if (content instanceof KeyValuePair) {
+    } else if (content instanceof this.namespace.KeyValuePair) {
       var pair = {
         'key': this.serialise(content.key),
       };
@@ -261,7 +260,7 @@ module.exports = createClass({
       if (content.element) {
         return this.deserialise(content);
       } else if (content.key) {
-        var pair = new KeyValuePair(this.deserialise(content.key));
+        var pair = new this.namespace.KeyValuePair(this.deserialise(content.key));
 
         if (content.value) {
           pair.value = this.deserialise(content.value);

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -3,8 +3,6 @@
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
 var KeyValuePair = require('../key-value-pair');
-var Element = require('../primitives/element');
-var ArrayElement = require('../primitives/array-element');
 
 module.exports = createClass({
   constructor: function(namespace) {
@@ -12,7 +10,7 @@ module.exports = createClass({
   },
 
   serialise: function(element) {
-    if (!(element instanceof Element)) {
+    if (!(element instanceof this.namespace.elements.Element)) {
       throw new TypeError('Given element `' + element + '` is not an Element instance');
     }
 
@@ -77,16 +75,16 @@ module.exports = createClass({
     var attributes = element.attributes.clone();
 
     // Enumerations attribute was is placed inside content (see `enumSerialiseContent` below)
-    var enumerations = attributes.remove('enumerations') || new ArrayElement([]);
+    var enumerations = attributes.remove('enumerations') || new this.namespace.elements.Array([]);
 
     // Wrap default in array
     var defaultValue = attributes.get('default');
     if (defaultValue && defaultValue.content) {
       defaultValue.content.attributes.remove('typeAttributes');
-      attributes.set('default', new ArrayElement([defaultValue.content]));
+      attributes.set('default', new this.namespace.elements.Array([defaultValue.content]));
     }
 
-    var samples = attributes.get('samples') || new ArrayElement([]);
+    var samples = attributes.get('samples') || new this.namespace.elements.Array([]);
     samples.forEach(function (sample) {
       sample.content.attributes.remove('typeAttributes');
     });
@@ -99,8 +97,8 @@ module.exports = createClass({
     }
 
     samples = samples.map(function(sample) {
-      return new ArrayElement([sample.content]);
-    });
+      return new this.namespace.elements.Array([sample.content]);
+    }, this);
 
     if (samples.length) {
       attributes.set('samples', samples);
@@ -184,7 +182,7 @@ module.exports = createClass({
 
         var existingSamples = samples;
 
-        samples = new ArrayElement();
+        samples = new this.namespace.elements.Array();
         existingSamples.forEach(function(sample) {
           sample.forEach(function (sample) {
             var enumElement = new ElementClass(sample);
@@ -239,7 +237,7 @@ module.exports = createClass({
   // Private API
 
   serialiseContent: function(content) {
-    if (content instanceof this.namespace.Element) {
+    if (content instanceof this.namespace.elements.Element) {
       return this.serialise(content);
     } else if (content instanceof KeyValuePair) {
       var pair = {

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -3,7 +3,6 @@
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
 var KeyValuePair = require('../key-value-pair');
-var Element = require('../primitives/element');
 
 /**
  * @class JSONSerialiser
@@ -23,7 +22,7 @@ module.exports = createClass({
    * @memberof JSONSerialiser.prototype
    */
   serialise: function(element) {
-    if (!(element instanceof Element)) {
+    if (!(element instanceof this.namespace.elements.Element)) {
       throw new TypeError('Given element `' + element + '` is not an Element instance');
     }
 
@@ -84,7 +83,7 @@ module.exports = createClass({
   // Private API
 
   serialiseContent: function(content) {
-    if (content instanceof this.namespace.Element) {
+    if (content instanceof this.namespace.elements.Element) {
       return this.serialise(content);
     } else if (content instanceof KeyValuePair) {
       var pair = {

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -2,7 +2,6 @@
 
 var createClass = require('uptown').createClass;
 var Namespace = require('../namespace');
-var KeyValuePair = require('../key-value-pair');
 
 /**
  * @class JSONSerialiser
@@ -85,7 +84,7 @@ module.exports = createClass({
   serialiseContent: function(content) {
     if (content instanceof this.namespace.elements.Element) {
       return this.serialise(content);
-    } else if (content instanceof KeyValuePair) {
+    } else if (content instanceof this.namespace.KeyValuePair) {
       var pair = {
         'key': this.serialise(content.key),
       };
@@ -111,7 +110,7 @@ module.exports = createClass({
       if (content.element) {
         return this.deserialise(content);
       } else if (content.key) {
-        var pair = new KeyValuePair(this.deserialise(content.key));
+        var pair = new this.namespace.KeyValuePair(this.deserialise(content.key));
 
         if (content.value) {
           pair.value = this.deserialise(content.value);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {


### PR DESCRIPTION
I discovered some problems when I was using `npm link` with fury-cli as it can introduce multiple versions of minim and if a user is doing something like the following:

```js
import fury from 'fury';
import JSON06Serialiser from 'minim/lib/serialisers/json-0.6';

const serialiser = new JSON06Serialiser(fury.minim);
```

They could end up in a state where fury.minim is for a different instance of minim than what `minim/lib/serialisers/json-0.6` is duing the import thus the created serialiser could be incompatible with the namespace passed to the serialiser and checks such as "instanceof Element" could fail. Respecting the given namespace prevents this from happening.