### PR TITLE
Restore metadata to be an array element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.20.7
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a regression from 0.20.6 where `metadata` became an `ObjectElement`
+  instead of `ArrayElement` as it was in the past.
+
 ## 0.20.6
 
 ### Bug Fixes

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -218,13 +218,6 @@ module.exports = createClass({
       var metadata = element.attributes.get('meta');
 
       if (metadata) {
-        if (metadata.element === 'array') {
-          // "meta" was deserialised as array
-          var content = metadata.content;
-          metadata = new this.namespace.elements.Object();
-          metadata.content = content;
-        }
-
         element.attributes.set('metadata', metadata);
         element.attributes.remove('meta');
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -883,11 +883,12 @@ describe('JSON 0.6 Serialiser', function() {
       });
 
       var metadata = category.attributes.get('metadata');
-      expect(metadata).to.be.instanceof(minim.elements.Object);
+      expect(metadata).to.be.instanceof(minim.elements.Array);
 
-      var member = metadata.getMember('HOST');
+      var member = metadata.get(0);
       expect(member).to.be.instanceof(minim.elements.Member);
       expect(member.classes.toValue()).to.deep.equal(['user']);
+      expect(member.key.toValue()).to.equal('HOST');
       expect(member.value.toValue()).to.equal('https://example.com');
     });
 


### PR DESCRIPTION
In #185 I incorrectly changed metadata from Refract 0.6 to be deserialised as
an Object instead of as an Array. A common problem with Refract 0.6 is that
certain elements have been serialised as arrays when they are not actually
array elements thus leading to tooling having to know more upfront knowledge
about what is expected in each meta, attribute or content to know if it should
deserialise an array as for example an enum element instead of an array
element.

One of the main design factors in Refract 1.0 (API Elements 1.0) was that every
possible element would be fully "refracted" as an JSON object with an element
name so tooling knows upfront what the type of element it contains.

The "meta" attribute is one of those types of elements which used to be
serialised as an array. As meta was a collection of `member` elements then it
is logically an object element and thus the change was made. However when the
change was made I was under the assumption that the spec and all of the other
tooling (Swagger parser) etc specificed and generated metadata as an object
element.

Turns out that is not the case, the spec says metadata is an Array, and the
Swagger parser, and API Blueprint parser is generating an Array element as
metadata. While I believe that may be a bug in API Elements design because
logically it should be declared as an object element. As this is not the case,
then my change in #185 was a breaking change and should be reverted.