### PR TITLE
Allow setting object element content to array of members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@
     const { JSON06Serialiser } = require('minim');
     ```
 
+### Enhancements
+
+- Object Element can now be created with an array of member elements.
+
+### Bug Fixes
+
+- The default content value of an element is undefined. Whereas before the
+  default value was `null`.
+
+- Setting the `content` property on an Element now behaves the same as passing
+  content in to the constructor. For example, the following two elements are
+  identical:
+
+  ```js
+  new ArrayElement([1])
+
+  const element = new ArrayElement()
+  element.content = [1]
+  ```
+
+  Passing `[1]` to an `ArrayElement` constructor would produce an array of
+  number elements, whereas setting the content to `[1]` resulted in setting the
+  content to be an array of non-elements which is invalid.
+
 ## 0.20.7
 
 ### Bug Fixes

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -49,6 +49,7 @@ function refract(value) {
 
 Element.prototype.ObjectElement = ObjectElement;
 Element.prototype.RefElement = RefElement;
+Element.prototype.MemberElement = MemberElement;
 
 Element.prototype.refract = refract;
 ArraySlice.prototype.refract = refract;

--- a/lib/primitives/array-element.js
+++ b/lib/primitives/array-element.js
@@ -15,12 +15,8 @@ var negate = require('lodash/negate');
  */
 var ArrayElement = Element.extend({
   constructor: function (content, meta, attributes) {
-    Element.call(this, [], meta || {}, attributes || {});
+    Element.call(this, content || [], meta, attributes);
     this.element = 'array';
-
-    if (content) {
-      content.forEach(this.push, this);
-    }
   },
 
   primitive: function() {

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -27,7 +27,7 @@ var Element = createClass({
       this.attributes = attributes;
     }
 
-    this.content = content !== undefined ? content : null;
+    this.content = content;
   },
 
   /**
@@ -262,6 +262,36 @@ var Element = createClass({
     },
     set: function(element) {
       this._storedElement = element;
+    }
+  },
+
+  content: {
+    get: function () {
+      return this._content;
+    },
+    set: function (value) {
+      if (value instanceof Element) {
+        this._content = value;
+      } else if (
+        typeof value == 'string' ||
+        typeof value == 'number' ||
+        typeof value == 'boolean' ||
+        typeof value == 'null' ||
+        value == undefined
+      ) {
+        // Primitive Values
+        this._content = value;
+      } else if (value instanceof KeyValuePair) {
+        this._content = value;
+      } else if (Array.isArray(value)) {
+        this._content = value.map(this.refract);
+      } else if (typeof value === 'object') {
+        this._content = Object.keys(value).map(function(key) {
+          return new this.MemberElement(key, value[key]);
+        }, this);
+      } else {
+        throw new Error('Cannot set content to given value');
+      }
     }
   },
 

--- a/lib/primitives/member-element.js
+++ b/lib/primitives/member-element.js
@@ -17,10 +17,10 @@ var Element = require('./element');
 module.exports = Element.extend({
   constructor: function(key, value, meta, attributes) {
     Element.call(this, new KeyValuePair(), meta, attributes);
-    this.element = 'member';
 
-    this.key = this.refract(key);
-    this.value = this.refract(value);
+    this.element = 'member';
+    this.key = key;
+    this.value = value;
   }
 }, {}, {
   /**

--- a/lib/primitives/null-element.js
+++ b/lib/primitives/null-element.js
@@ -7,8 +7,8 @@ var Element = require('./element');
  * @extends Element
  */
 module.exports = Element.extend({
-  constructor: function() {
-    Element.apply(this, arguments);
+  constructor: function(content, meta, attributes) {
+    Element.call(this, content || null, meta, attributes);
     this.element = 'null';
   },
 

--- a/lib/primitives/object-element.js
+++ b/lib/primitives/object-element.js
@@ -19,10 +19,7 @@ var ObjectSlice = require('../object-slice');
  */
 var ObjectElement = ArrayElement.extend({
   constructor: function (content, meta, attributes) {
-    var convertedContent = Object.keys(content || {}).map(function(key) {
-      return new MemberElement(key, content[key]);
-    });
-    Element.call(this, convertedContent, meta, attributes);
+    Element.call(this, content || [], meta, attributes);
     this.element = 'object';
   },
 

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -40,6 +40,11 @@ describe('Element', function() {
   describe('when initializing with value', function() {
     var el;
 
+    it('should properly default to undefined', function() {
+      el = new minim.Element();
+      expect(el.toValue()).to.equal(undefined);
+    });
+
     it('should properly serialize falsey string', function() {
       el = new minim.Element('');
       expect(el.toValue()).to.equal('');
@@ -97,6 +102,82 @@ describe('Element', function() {
     });
   });
 
+  describe('#content', function() {
+    var element;
+
+    before(function() {
+      element = new minim.Element();
+    });
+
+    it('should allow setting undefined', function() {
+      element.content = undefined;
+
+      expect(element.content).to.equal(undefined);
+    });
+
+    it('should allow setting null', function() {
+      element.content = null;
+
+      expect(element.content).to.equal(null);
+    });
+
+    it('should allow setting boolean value', function() {
+      element.content = true;
+
+      expect(element.content).to.equal(true);
+    });
+
+    it('should allow setting string value', function() {
+      element.content = '';
+
+      expect(element.content).to.equal('');
+    });
+
+    it('should allow setting number value', function() {
+      element.content = 5;
+
+      expect(element.content).to.equal(5);
+    });
+
+    it('should allow setting element value', function() {
+      element.content = new minim.Element();
+
+      expect(element.content).to.deep.equal(new minim.Element());
+    });
+
+    it('should allow setting array of elements', function() {
+      element.content = [new minim.Element(1)];
+
+      expect(element.content).to.deep.equal([
+        new minim.Element(1)
+      ]);
+    });
+
+    it('should allow setting array of non-elements', function() {
+      element.content = [true];
+
+      expect(element.content).to.deep.equal([
+        new minim.elements.Boolean(true)
+      ]);
+    });
+
+    it('should allow setting object', function() {
+      element.content = {
+        name: 'Doe'
+      };
+
+      expect(element.content).to.deep.equal([
+        new minim.elements.Member('name', 'Doe')
+      ]);
+    });
+
+    it('should allow setting KeyValuePair', function() {
+      element.content = new KeyValuePair();
+
+      expect(element.content).to.deep.equal(new KeyValuePair());
+    });
+  });
+
   describe('#element', function() {
     context('when getting an element that has not been set', function() {
       var el;
@@ -135,7 +216,7 @@ describe('Element', function() {
     var el;
 
     before(function() {
-      el = new minim.Element({
+      el = new minim.elements.Object({
         foo: 'bar'
       }, {
         id: 'foobar'

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -84,14 +84,26 @@ describe('JSON 0.6 Serialiser', function() {
     });
 
     it('serialise an element with object content', function() {
-      var element = new minim.elements.Element({ message: 'hello' });
+      var element = new minim.Element({ message: 'hello' });
       var object = serialiser.serialise(element);
 
       expect(object).to.deep.equal({
         element: 'element',
-        content: {
-          message: 'hello'
-        }
+        content: [
+          {
+            element: 'member',
+            content: {
+              key: {
+                element: 'string',
+                content: 'message',
+              },
+              value: {
+                element: 'string',
+                content: 'hello',
+              },
+            }
+          }
+        ]
       });
     });
 
@@ -535,14 +547,14 @@ describe('JSON 0.6 Serialiser', function() {
 
     it('deserialises from a JSON object containing JSON object content', function() {
       var element = serialiser.deserialise({
-        element: 'element',
+        element: 'object',
         content: {
           message: 'hello'
         }
       });
 
       expect(element).to.be.instanceof(minim.elements.Element);
-      expect(element.content).to.deep.equal({ message: 'hello' });
+      expect(element.toValue()).to.deep.equal({ message: 'hello' });
     });
 
     it('deserialise from a JSON object containing a key-value pair', function() {

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -82,19 +82,6 @@ describe('JSON Serialiser', function() {
       });
     });
 
-
-    it('serialise an element with object content', function() {
-      var element = new minim.elements.Element({ message: 'hello' });
-      var object = serialiser.serialise(element);
-
-      expect(object).to.deep.equal({
-        element: 'element',
-        content: {
-          message: 'hello'
-        }
-      });
-    });
-
     it('serialises an element containing a pair', function() {
       var name = new minim.elements.String('name')
       var doe = new minim.elements.String('Doe')

--- a/test/subclass-test.js
+++ b/test/subclass-test.js
@@ -128,7 +128,6 @@ describe('Minim subclasses', function() {
             ],
           },
         },
-        content: null
       });
     });
 


### PR DESCRIPTION
Before, you could only invoke an object element with JSON object (`{}`), you couldn't provide a collection of member elements. So if you wanted to create an object element with pre-created members you'd have to do the following:

```js
const member = ...
member.sourceMapValue = [1,2];

const object = new ObjectElement({});
object.push(member);
```

Now you can do the following:

```js
const member = ...
member.sourceMapValue = [1,2];

const object = new ObjectElement([member]);
```

The change also resulted in removing some broken behaviours such as the following, which all sets the content to something invalid:

```json
element.content = {}
```


```json
element.content = [1]
```

This will also fix a bug such as the following:

```js
const element = new Element()
element.element = 'User'
```

Which would be serialised as:

```json
{
  "element": "User",
  "content": "null"
}
```

Instead of:

```json
{
  "element": "User"
}
```

For example in https://github.com/apiaryio/swagger-zoo/blob/31652f7cf93f9f7a636d17022ae6a8f1d7110b76/fixtures/features/api-elements/data-structures.json#L95-L96