### PR TITLE
Don't serialise empty arrays unless request/response or category in JSON 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
   is updated to reflect API Elements 1.0. The `variable` attribute is now
   present on a member element instead of the key of a member element.
 
+- Empty arrays are no longer serialised in JSON 06 Serialiser.
+
 ## 0.20.7
 
 ### Bug Fixes

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -64,12 +64,28 @@ module.exports = JSONSerialiser.extend({
         content = this.serialiseContent(element.content);
       }
 
-      if (content !== undefined) {
+      if (this.shouldSerialiseContent(element, content)) {
         payload['content'] = content;
       }
     }
 
     return payload;
+  },
+
+  shouldSerialiseContent: function(element, content) {
+    if (content === undefined) {
+      return false;
+    }
+
+    if (element.element === 'httpRequest' || element.element === 'httpResponse' || element.element === 'category') {
+      return true;
+    }
+
+    if (Array.isArray(content) && content.length === 0) {
+      return false;
+    }
+
+    return true;
   },
 
   refSerialiseContent: function(element, payload) {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -78,8 +78,7 @@ describe('JSON 0.6 Serialiser', function() {
       var object = serialiser.serialise(element);
 
       expect(object).to.deep.equal({
-        element: 'array',
-        content: []
+        element: 'array'
       });
     });
 
@@ -434,7 +433,6 @@ describe('JSON 0.6 Serialiser', function() {
             ]
           ]
         },
-        content: [],
       });
     });
 
@@ -464,7 +462,6 @@ describe('JSON 0.6 Serialiser', function() {
             }
           ]
         },
-        content: [],
       });
     });
 
@@ -820,6 +817,39 @@ describe('JSON 0.6 Serialiser', function() {
             content: 'https://example.com',
           }
         }
+      });
+    });
+
+    it('serialises empty httpRequest content', function() {
+      var element = new minim.elements.Element([]);
+      element.element = 'httpRequest';
+      var serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'httpRequest',
+        content: []
+      });
+    });
+
+    it('serialises empty httpResponse content', function() {
+      var element = new minim.elements.Element([]);
+      element.element = 'httpResponse';
+      var serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'httpResponse',
+        content: []
+      });
+    });
+
+    it('serialises empty category content', function() {
+      var element = new minim.elements.Element([]);
+      element.element = 'category';
+      var serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'category',
+        content: []
       });
     });
   });


### PR DESCRIPTION
This aligns with Drafter 3 behaviour where empty arrays are not serialised, except for request/response or category elements.