### PR TITLE
Fix `variable` property serialisation in 0.6 serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   number elements, whereas setting the content to `[1]` resulted in setting the
   content to be an array of non-elements which is invalid.
 
+- The serialisation of the `variable` attribute in the JSON 0.6 serialisation
+  is updated to reflect API Elements 1.0. The `variable` attribute is now
+  present on a member element instead of the key of a member element.
+
 ## 0.20.7
 
 ### Bug Fixes

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -8,6 +8,11 @@ module.exports = JSONSerialiser.extend({
       throw new TypeError('Given element `' + element + '` is not an Element instance');
     }
 
+    var variable;
+    if (element._attributes && element.attributes.get('variable')) {
+      variable = element.attributes.get('variable');
+    }
+
     var payload = {
       element: element.element,
     };
@@ -34,7 +39,14 @@ module.exports = JSONSerialiser.extend({
         attributes.remove('metadata');
       }
 
-      payload['attributes'] = this.serialiseObject(attributes);
+      if (element.element === 'member' && variable) {
+        attributes = attributes.clone();
+        attributes.remove('variable');
+      }
+
+      if (attributes.length > 0) {
+        payload['attributes'] = this.serialiseObject(attributes);
+      }
     }
 
     if (isEnum) {
@@ -42,7 +54,15 @@ module.exports = JSONSerialiser.extend({
     } else if (this[element.element + 'SerialiseContent']) {
       payload['content'] = this[element.element + 'SerialiseContent'](element, payload);
     } else if (element.content !== undefined) {
-      var content = this.serialiseContent(element.content);
+      var content;
+
+      if (variable && element.content.key) {
+        content = element.content.clone();
+        content.key.attributes.set('variable', variable);
+        content = this.serialiseContent(content);
+      } else {
+        content = this.serialiseContent(element.content);
+      }
 
       if (content !== undefined) {
         payload['content'] = content;
@@ -222,6 +242,9 @@ module.exports = JSONSerialiser.extend({
         element.attributes.set('metadata', metadata);
         element.attributes.remove('meta');
       }
+    } else if (element.element === 'member' && element.key && element.key._attributes && element.key._attributes.getValue('variable')) {
+      element.attributes.set('variable', element.key.attributes.get('variable'));
+      element.key.attributes.remove('variable');
     }
 
     return element;

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -799,6 +799,29 @@ describe('JSON 0.6 Serialiser', function() {
         content: null
       });
     });
+
+    it('serialises a variable member', function() {
+      var element = new minim.elements.Member('self', 'https://example.com');
+      element.attributes.set('variable', true);
+      var object = serialiser.serialise(element);
+
+      expect(object).to.deep.equal({
+        element: 'member',
+        content: {
+          key: {
+            element: 'string',
+            attributes: {
+              variable: true
+            },
+            content: 'self',
+          },
+          value: {
+            element: 'string',
+            content: 'https://example.com',
+          }
+        }
+      });
+    });
   });
 
   describe('deserialisation', function() {
@@ -1198,6 +1221,29 @@ describe('JSON 0.6 Serialiser', function() {
       expect(member.classes.toValue()).to.deep.equal(['user']);
       expect(member.key.toValue()).to.equal('HOST');
       expect(member.value.toValue()).to.equal('https://example.com');
+    });
+
+    it('deserialises a variable member', function() {
+      var member = serialiser.deserialise({
+        element: 'member',
+        content: {
+          key: {
+            element: 'self',
+            attributes: {
+              variable: true,
+            },
+            content: 'https://example.com',
+          },
+          value: {
+            element: 'string',
+            content: 'https://example.com',
+          }
+        }
+      });
+
+      expect(member).to.be.instanceof(minim.elements.Member);
+      expect(member.attributes.getValue('variable')).to.be.true;
+      expect(member.key.attributes.get('variable')).to.be.undefined;
     });
 
     describe('deserialising base elements', function() {


### PR DESCRIPTION
`variable` property was moved from the key to the member itself.