### PR TITLE
Support creating elements from slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
 
 - Object Element can now be created with an array of member elements.
 
+- You can now create an element from an ArraySlice or ObjectSlice, for example,
+  passing the result of a `filter` operation into a new element.
+
+  ```
+  const numbers = new ArrayElement([1, 2, 3, 4])
+  new ArrayElement(numbers.filter((e) => e.toValue() % 2))
+  ```
+
 - Adds `compactMap` functionality to Array and Object elements allowing you to
   returns an array containing the truthy results of calling the given
   transformation with each element of this sequence.

--- a/lib/primitives/element.js
+++ b/lib/primitives/element.js
@@ -272,6 +272,8 @@ var Element = createClass({
     set: function (value) {
       if (value instanceof Element) {
         this._content = value;
+      } else if (value instanceof ArraySlice) {
+        this.content = value.elements;
       } else if (
         typeof value == 'string' ||
         typeof value == 'number' ||

--- a/test/primitives/base-element-test.js
+++ b/test/primitives/base-element-test.js
@@ -3,6 +3,8 @@ var minim = require('../../lib/minim').namespace();
 var KeyValuePair = require('../../lib/key-value-pair');
 var RefElement = require('../../lib/minim').RefElement;
 var ArraySlice = require('../../lib/minim').ArraySlice;
+var ObjectSlice = require('../../lib/minim').ObjectSlice;
+var NumberElement = require('../../lib/minim').NumberElement;
 
 describe('Element', function() {
   context('when initializing', function() {
@@ -175,6 +177,24 @@ describe('Element', function() {
       element.content = new KeyValuePair();
 
       expect(element.content).to.deep.equal(new KeyValuePair());
+    });
+
+    it('should allow setting ArraySlice (converted to array)', function() {
+      element.content = new ArraySlice([1, 2]);
+
+      expect(element.content).to.deep.equal([
+        new NumberElement(1),
+        new NumberElement(2)
+      ]);
+    });
+
+    it('should allow setting ObjectSlice (converted to array)', function() {
+      var MemberElement = minim.getElementClass('member');
+      element.content = new ObjectSlice([new MemberElement("name", "Doe")]);
+
+      expect(element.content).to.deep.equal([
+        new MemberElement("name", "Doe"),
+      ]);
     });
   });
 


### PR DESCRIPTION
For example, the following `ArrayElement.filter()` returns an `ArraySlice` and thus wasn't possible to pass to a constructor or content of an element. This PR allows you to coerce a slice into an element easier:

```js
const numbers = new ArrayElement([1, 2, 3, 4])
new ArrayElement(numbers.filter((e) => e.toValue() % 2))
```