### PR TITLE
Serialise parseResult and link empty array content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.21.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Empty parseResult and link arrays are serialised in JSON 06 Serialiser, a
+  regression of 0.21.0 caused these to not be serialised.
+
 ## 0.21.0
 
 ### Breaking

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -77,7 +77,10 @@ module.exports = JSONSerialiser.extend({
       return false;
     }
 
-    if (element.element === 'httpRequest' || element.element === 'httpResponse' || element.element === 'category') {
+    if (element.element === 'parseResult' || element.element === 'httpRequest' ||
+        element.element === 'httpResponse' || element.element === 'category' ||
+        element.element === 'link')
+    {
       return true;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -820,6 +820,17 @@ describe('JSON 0.6 Serialiser', function() {
       });
     });
 
+    it('serialises empty parseResult content', function() {
+      var element = new minim.elements.Element([]);
+      element.element = 'parseResult';
+      var serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'parseResult',
+        content: []
+      });
+    });
+
     it('serialises empty httpRequest content', function() {
       var element = new minim.elements.Element([]);
       element.element = 'httpRequest';
@@ -839,6 +850,17 @@ describe('JSON 0.6 Serialiser', function() {
       expect(serialised).to.deep.equal({
         element: 'httpResponse',
         content: []
+      });
+    });
+
+    it('serialises empty link content', function() {
+      var element = new minim.elements.Element([]);
+      element.element = 'link';
+      var serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'link',
+        content: [],
       });
     });
 


### PR DESCRIPTION
This fixes a regression in 0.21.0 caught by integration tests in our parsing service.