### PR TITLE
Allow serialising undefined members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes serialising an element with an undefined meta or attributes value. For
+  example if a meta value (`id`) was set to `undefined`, then it should not be
+  serialised. Previously the serialiser would throw an exception that
+  undefined was not an element.
+
 ## 0.22.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.22.1 (2018-12-10)
 
 ### Bug Fixes
 

--- a/lib/serialisers/json-0.6.js
+++ b/lib/serialisers/json-0.6.js
@@ -390,7 +390,11 @@ module.exports = JSONSerialiser.extend({
     var result = {};
 
     obj.keys().forEach(function (key) {
-      result[key] = this.convertKeyToRefract(key, obj.get(key));
+      var value = obj.get(key);
+
+      if (value) {
+        result[key] = this.convertKeyToRefract(key, value);
+      }
     }, this);
 
     return result;

--- a/lib/serialisers/json.js
+++ b/lib/serialisers/json.js
@@ -129,7 +129,11 @@ module.exports = createClass({
     var result = {};
 
     obj.keys().forEach(function (key) {
-      result[key] = this.serialise(obj.get(key));
+      var value = obj.get(key);
+
+      if (value) {
+        result[key] = this.serialise(value);
+      }
     }, this);
 
     return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/json-0.6.js
+++ b/test/serialisers/json-0.6.js
@@ -23,6 +23,24 @@ describe('JSON 0.6 Serialiser', function() {
   });
 
   describe('serialisation', function() {
+    describe('#serialiseObject', function() {
+      it('can serialise an ObjectElement', function () {
+        var object = new minim.elements.Object({ id: 'Example' });
+        var result = serialiser.serialiseObject(object);
+
+        expect(result).to.deep.equal({
+          id: 'Example',
+        });
+      });
+
+      it('can serialise an ObjectElement containg undefined key', function () {
+        var object = new minim.elements.Object({ key: undefined });
+        var result = serialiser.serialiseObject(object);
+
+        expect(result).to.deep.equal({});
+      });
+    });
+
     it('errors when serialising a non-element', function() {
       expect(function(){
         serialiser.serialise('Hello');

--- a/test/serialisers/json.js
+++ b/test/serialisers/json.js
@@ -23,6 +23,27 @@ describe('JSON Serialiser', function() {
   });
 
   describe('serialisation', function() {
+    describe('#serialiseObject', function() {
+      it('can serialise an ObjectElement', function () {
+        var object = new minim.elements.Object({ id: 'Example' });
+        var result = serialiser.serialiseObject(object);
+
+        expect(result).to.deep.equal({
+          id: {
+            element: 'string',
+            content: 'Example',
+          },
+        });
+      });
+
+      it('can serialise an ObjectElement containg undefined key', function () {
+        var object = new minim.elements.Object({ key: undefined });
+        var result = serialiser.serialiseObject(object);
+
+        expect(result).to.deep.equal({});
+      });
+    });
+
     it('errors when serialising a non-element', function() {
       expect(function(){
         serialiser.serialise('Hello');


### PR DESCRIPTION
This fixes a problem where trying to serialise the following results in an error being throw:

```js
object.set('key', undefined);
serialiser.serialise(object);
```

The new behaviour aligns to how "JSON" serialisation works in plain JS:

```js
> JSON.stringify({ key: undefined })
'{}'
```

This was catching me out elsewhere as the following code was causing an error during serialsiation:

```js
function generateHrefVariables() {
  // some code path where there are no href variables so undefined is returned
  return undefined;
}

resource.hrefVariables = generateHrefVariables();
```

Undefined is used to 'unset' a value too.