### PR TITLE
Release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.23.0 (2019-02-22)
 
 ### Breaking
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {


### PR DESCRIPTION
### Breaking

- Support for Node 4 has been removed. Minim now supports Node >= 6.
- Minim no longer uses [uptown](http://github.com/smizell/uptown) and thus the
  `extend` API has been removed.
### Enhancements
- Calling `.freeze()` on a frozen element is now supported. Previously you may
  see an error thrown while freeze was trying to attach parents to any child
elements.