### PR TITLE
Restore documentation coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.23.1 (2019-02-25)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Restores documentation coverage for all elements, some was unintentionally
+  removed in 0.23.0.
+
 ## 0.23.0 (2019-02-22)
 
 ### Breaking

--- a/lib/ObjectSlice.js
+++ b/lib/ObjectSlice.js
@@ -1,6 +1,8 @@
 const negate = require('lodash/negate');
 const ArraySlice = require('./ArraySlice');
 
+/**
+ */
 class ObjectSlice extends ArraySlice {
   map(callback, thisArg) {
     return this.elements.map(member => callback.bind(thisArg)(member.value, member.key, member));

--- a/lib/primitives/ArrayElement.js
+++ b/lib/primitives/ArrayElement.js
@@ -280,6 +280,9 @@ class ArrayElement extends Element {
 
   // Fantasy Land
 
+  /**
+   * @returns {ArrayElement} An empty array element
+   */
   empty() {
     return new this.constructor([]);
   }
@@ -288,6 +291,10 @@ class ArrayElement extends Element {
     return this.empty();
   }
 
+  /**
+   * @param {ArrayElement} other
+   * @returns {ArrayElement}
+   */
   concat(other) {
     return new this.constructor(this.content.concat(other.content));
   }
@@ -355,6 +362,9 @@ class ArrayElement extends Element {
   }
 }
 
+/**
+ * @returns {ArrayElement} An empty array element
+ */
 ArrayElement.empty = function empty() {
   return new this();
 };

--- a/lib/primitives/Element.js
+++ b/lib/primitives/Element.js
@@ -93,6 +93,8 @@ class Element {
     return copy;
   }
 
+  /**
+   */
   toValue() {
     if (this.content instanceof Element) {
       return this.content.toValue();
@@ -280,7 +282,7 @@ class Element {
   }
 
   /**
-   * @type this.ObjectElement
+   * @type ObjectElement
    */
   get meta() {
     if (!this._meta) {
@@ -308,7 +310,7 @@ class Element {
    * The attributes property defines attributes about the given instance
    * of the element, as specified by the element property.
    *
-   * @type this.ObjectElement
+   * @type ObjectElement
    */
   get attributes() {
     if (!this._attributes) {

--- a/lib/primitives/NullElement.js
+++ b/lib/primitives/NullElement.js
@@ -1,6 +1,8 @@
 const Element = require('./Element');
 
-module.exports = class NullElement extends Element {
+/**
+ */
+class NullElement extends Element {
   constructor(content, meta, attributes) {
     super(content || null, meta, attributes);
     this.element = 'null';
@@ -13,4 +15,6 @@ module.exports = class NullElement extends Element {
   set() {
     return new Error('Cannot set the value of null');
   }
-};
+}
+
+module.exports = NullElement;

--- a/lib/primitives/ObjectElement.js
+++ b/lib/primitives/ObjectElement.js
@@ -111,10 +111,14 @@ class ObjectElement extends ArrayElement {
     return this;
   }
 
+  /**
+   */
   keys() {
     return this.content.map(item => item.key.toValue());
   }
 
+  /**
+   */
   values() {
     return this.content.map(item => item.value.toValue());
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {


### PR DESCRIPTION
https://github.com/refractproject/minim/pull/209 removed some documentation coverage which causes other classes that reference the documentation in other libraries to fail.

For example in https://github.com/apiaryio/api-elements.js/pull/168

> Sphinx error:
> No JSDoc documentation was found for object "NullElement" or any path ending with that.