### PR TITLE
Fix handling of array/object enum samples in JSON 0.6 serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes serialisation of array and object sample values in enumerations in
+  Refract JSON 0.6 serialisation.
+
 ## 0.23.1 (2019-02-25)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.23.2 (2019-03-15)
 
 ### Bug Fixes
 

--- a/lib/serialisers/JSON06Serialiser.js
+++ b/lib/serialisers/JSON06Serialiser.js
@@ -121,8 +121,11 @@ module.exports = class JSON06Serialiser extends JSONSerialiser {
       attributes.set('default', new this.namespace.elements.Array([defaultValue.content]));
     }
 
+    // Strip typeAttributes from samples, 0.6 doesn't usually contain them in samples
     samples.forEach((sample) => {
-      sample.content.attributes.remove('typeAttributes');
+      if (sample.content && sample.content.element) {
+        sample.content.attributes.remove('typeAttributes');
+      }
     });
 
     // Content -> Samples
@@ -132,7 +135,13 @@ module.exports = class JSON06Serialiser extends JSONSerialiser {
       samples.unshift(element.content);
     }
 
-    samples = samples.map(sample => new this.namespace.elements.Array([sample.content]));
+    samples = samples.map((sample) => {
+      if (sample instanceof this.namespace.elements.Array) {
+        return [sample];
+      }
+
+      return new this.namespace.elements.Array([sample.content]);
+    });
 
     if (samples.length) {
       attributes.set('samples', samples);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/JSON06Serialiser-test.js
+++ b/test/serialisers/JSON06Serialiser-test.js
@@ -341,6 +341,52 @@ describe('JSON 0.6 Serialiser', () => {
       // }
     });
 
+    it('serialises enum with object samples', () => {
+      const object = new minim.elements.Object();
+      const array = new minim.elements.Array();
+
+      const sample = new minim.elements.Object({ message: 'Hello World' });
+
+      const enumeration = new minim.Element();
+      enumeration.element = 'enum';
+      enumeration.attributes.set('enumerations', [object, array]);
+      enumeration.attributes.set('samples', [sample]);
+
+      const result = serialiser.serialise(enumeration);
+
+      expect(result).to.deep.equal({
+        element: 'enum',
+        attributes: {
+          samples: [
+            [
+              {
+                element: 'object',
+                content: [
+                  {
+                    element: 'member',
+                    content: {
+                      key: {
+                        element: 'string',
+                        content: 'message',
+                      },
+                      value: {
+                        element: 'string',
+                        content: 'Hello World',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          ],
+        },
+        content: [
+          { element: 'object' },
+          { element: 'array' },
+        ],
+      });
+    });
+
     it('serialises enum with fixed values', () => {
       const defaultElement = new minim.Element(new minim.elements.String('North'));
       defaultElement.element = 'enum';


### PR DESCRIPTION
Given the following API Element:

```json
{
  "element": "enum",
  "meta": {
    "id": {
      "element": "string",
      "content": "Schema"
    }
  },
  "attributes": {
    "enumerations": {
      "element": "array",
      "content": [
        {
          "element": "string"
        },
        {
          "element": "number"
        },
        {
          "element": "boolean"
        },
        {
          "element": "object"
        },
        {
          "element": "array"
        }
      ]
    },
    "samples": {
      "element": "array",
      "content": [
        {
          "element": "object",
          "content": [
            {
              "element": "member",
              "content": {
                "key": {
                  "element": "string",
                  "content": "message"
                },
                "value": {
                  "element": "string",
                  "content": "Hello World"
                }
              }
            }
          ]
        }
      ]
    }
  }
}
```

Which is derved from OAS 3 document schema of:

```yaml
Schema:
  example:
    message: 'Hello World'
```

Since the schema isn't limited to any type, it's effectively an "enum" of all types, with an example value for an object with values.

This would previously raise the following exception:

```
TypeError: Cannot read property 'remove' of undefined
    at samples.forEach (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:125:33)
    at content.forEach (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/primitives/ArrayElement.js:174:29)
    at Array.forEach (<anonymous>)
    at ArrayElement.forEach (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/primitives/ArrayElement.js:173:18)
    at JSON06Serialiser.enumSerialiseAttributes (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:124:13)
    at JSON06Serialiser.serialise (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:25:31)
    at JSON06Serialiser.serialiseContent (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:281:19)
    at JSON06Serialiser.dataStructureSerialiseContent (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:105:18)
    at JSON06Serialiser.serialise (/Users/kyle/Projects/apiaryio/api-elements.js/node_modules/minim/lib/serialisers/JSON06Serialiser.js:53:67)
    at Array.map (<anonymous>)
```