### PR TITLE
Use ramda insead of lodash

### DIFF
--- a/lib/ArraySlice.js
+++ b/lib/ArraySlice.js
@@ -1,4 +1,4 @@
-const negate = require('lodash/negate');
+const complement = require('ramda/src/complement');
 
 // Coerces an a parameter into a callback for matching elements.
 // This accepts an element name, an element type and returns a
@@ -99,7 +99,7 @@ class ArraySlice {
    */
   reject(callback, thisArg) {
     callback = coerceElementMatchingCallback(callback);
-    return new ArraySlice(this.elements.filter(negate(callback), thisArg));
+    return new ArraySlice(this.elements.filter(complement(callback), thisArg));
   }
 
   /**

--- a/lib/Namespace.js
+++ b/lib/Namespace.js
@@ -1,9 +1,4 @@
-const isNull = require('lodash/isNull');
-const isString = require('lodash/isString');
-const isNumber = require('lodash/isNumber');
-const isBoolean = require('lodash/isBoolean');
-const isObject = require('lodash/isObject');
-
+const is = require('ramda/src/is');
 const JSONSerialiser = require('./serialisers/JSONSerialiser');
 const elements = require('./elements');
 
@@ -68,12 +63,12 @@ class Namespace {
     // Add instance detection functions to convert existing objects into
     // the corresponding refract elements.
     this
-      .detect(isNull, elements.NullElement, false)
-      .detect(isString, elements.StringElement, false)
-      .detect(isNumber, elements.NumberElement, false)
-      .detect(isBoolean, elements.BooleanElement, false)
-      .detect(Array.isArray, elements.ArrayElement, false)
-      .detect(isObject, elements.ObjectElement, false);
+      .detect(v => v === null, elements.NullElement, false)
+      .detect(is(String), elements.StringElement, false)
+      .detect(is(Number), elements.NumberElement, false)
+      .detect(is(Boolean), elements.BooleanElement, false)
+      .detect(is(Array), elements.ArrayElement, false)
+      .detect(is(Object), elements.ObjectElement, false);
 
     return this;
   }

--- a/lib/ObjectSlice.js
+++ b/lib/ObjectSlice.js
@@ -1,4 +1,4 @@
-const negate = require('lodash/negate');
+const complement = require('ramda/src/complement');
 const ArraySlice = require('./ArraySlice');
 
 /**
@@ -13,7 +13,7 @@ class ObjectSlice extends ArraySlice {
   }
 
   reject(callback, thisArg) {
-    return this.filter(negate(callback.bind(thisArg)));
+    return this.filter(complement(callback.bind(thisArg)));
   }
 
   forEach(callback, thisArg) {

--- a/lib/primitives/ArrayElement.js
+++ b/lib/primitives/ArrayElement.js
@@ -1,4 +1,4 @@
-const negate = require('lodash/negate');
+const complement = require('ramda/src/complement');
 const Element = require('./Element');
 const ArraySlice = require('../ArraySlice');
 
@@ -118,7 +118,7 @@ class ArrayElement extends Element {
    * @returns {ArraySlice}
    */
   reject(callback, thisArg) {
-    return this.filter(negate(callback), thisArg);
+    return this.filter(complement(callback), thisArg);
   }
 
   /**

--- a/lib/primitives/Element.js
+++ b/lib/primitives/Element.js
@@ -1,4 +1,4 @@
-const isEqual = require('lodash/isEqual');
+const equals = require('ramda/src/equals');
 const KeyValuePair = require('../KeyValuePair');
 const ArraySlice = require('../ArraySlice.js');
 
@@ -219,7 +219,7 @@ class Element {
   }
 
   equals(value) {
-    return isEqual(this.toValue(), value);
+    return equals(this.toValue(), value);
   }
 
   getMetaProperty(name, value) {

--- a/lib/primitives/ObjectElement.js
+++ b/lib/primitives/ObjectElement.js
@@ -1,6 +1,5 @@
-const negate = require('lodash/negate');
-const isObject = require('lodash/isObject');
-
+const complement = require('ramda/src/complement');
+const is = require('ramda/src/is');
 const ArrayElement = require('./ArrayElement');
 const MemberElement = require('./MemberElement');
 const ObjectSlice = require('../ObjectSlice');
@@ -90,7 +89,7 @@ class ObjectElement extends ArrayElement {
    * If an object is given, each key is set to its respective value
    */
   set(keyOrObject, value) {
-    if (isObject(keyOrObject)) {
+    if (is(Object, keyOrObject)) {
       Object.keys(keyOrObject).forEach((objectKey) => {
         this.set(objectKey, keyOrObject[objectKey]);
       });
@@ -190,7 +189,7 @@ class ObjectElement extends ArrayElement {
    * @memberof ObjectElement.prototype
    */
   reject(callback, thisArg) {
-    return this.filter(negate(callback), thisArg);
+    return this.filter(complement(callback), thisArg);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sinon": "^7.2.4"
   },
   "dependencies": {
-    "lodash": "^4.15.0"
+    "ramda": "^0.26.1"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
The biggest motivation was that we're using Ramda elsewhere which provides similiar functionality. This has a decent improvement in the overall bundle size, saving us 96K or 19% of the entire bundle size:

    $ du -h dist/*.js
    508K    dist/minim-with-lodash.js
    412K    dist/minim-with-ramda.js