### PR TITLE
Serialise objects as O(N) instead of O(N^2)

### DIFF
--- a/lib/serialisers/JSON06Serialiser.js
+++ b/lib/serialisers/JSON06Serialiser.js
@@ -406,11 +406,10 @@ module.exports = class JSON06Serialiser extends JSONSerialiser {
   serialiseObject(obj) {
     const result = {};
 
-    obj.keys().forEach((key) => {
-      const value = obj.get(key);
-
+    obj.forEach((value, key) => {
       if (value) {
-        result[key] = this.convertKeyToRefract(key, value);
+        const keyValue = key.toValue();
+        result[keyValue] = this.convertKeyToRefract(keyValue, value);
       }
     });
 

--- a/lib/serialisers/JSONSerialiser.js
+++ b/lib/serialisers/JSONSerialiser.js
@@ -129,11 +129,9 @@ class JSONSerialiser {
   serialiseObject(obj) {
     const result = {};
 
-    obj.keys().forEach((key) => {
-      const value = obj.get(key);
-
+    obj.forEach((value, key) => {
       if (value) {
-        result[key] = this.serialise(value);
+        result[key.toValue()] = this.serialise(value);
       }
     });
 


### PR DESCRIPTION
We're causing double loop of the elements in an object during serialisation which thus makes the serialisation slower. As we are looping over the keys, and then looking up the key from the content of an object again (thus causing secondary loop in `get`).