### PR TITLE
Serialise undefined 0.6 array content as empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Minim Changelog
 
+## Master
+
+### Bug Fixes
+
+- Fixes a JSON 0.6 serialisation bug where httpRequest and similar array-based
+  elements with undefined content would be serialised with undefined content
+  instead of an empty array as content.
+
 ## 0.23.5 (2019-07-02)
 
 This release brings some performance improvements, namely to serialising with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Minim Changelog
 
-## Master
+## 0.23.6 (2019-09-10)
 
 ### Bug Fixes
 

--- a/lib/serialisers/JSON06Serialiser.js
+++ b/lib/serialisers/JSON06Serialiser.js
@@ -65,20 +65,22 @@ module.exports = class JSON06Serialiser extends JSONSerialiser {
       if (this.shouldSerialiseContent(element, content)) {
         payload.content = content;
       }
+    } else if (this.shouldSerialiseContent(element, element.content) && element instanceof this.namespace.elements.Array) {
+      payload.content = [];
     }
 
     return payload;
   }
 
   shouldSerialiseContent(element, content) {
-    if (content === undefined) {
-      return false;
-    }
-
     if (element.element === 'parseResult' || element.element === 'httpRequest'
         || element.element === 'httpResponse' || element.element === 'category'
         || element.element === 'link') {
       return true;
+    }
+
+    if (content === undefined) {
+      return false;
     }
 
     if (Array.isArray(content) && content.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim",
-  "version": "0.23.5",
+  "version": "0.23.6",
   "description": "A library for interacting with JSON through Refract elements",
   "main": "lib/minim.js",
   "scripts": {

--- a/test/serialisers/JSON06Serialiser-test.js
+++ b/test/serialisers/JSON06Serialiser-test.js
@@ -928,6 +928,18 @@ describe('JSON 0.6 Serialiser', () => {
       });
     });
 
+    it('serialises undefined httpRequest content', () => {
+      const element = new minim.elements.Array();
+      element.element = 'httpRequest';
+      element.content = undefined;
+      const serialised = serialiser.serialise(element);
+
+      expect(serialised).to.deep.equal({
+        element: 'httpRequest',
+        content: [],
+      });
+    });
+
     it('serialises empty httpResponse content', () => {
       const element = new minim.elements.Element([]);
       element.element = 'httpResponse';


### PR DESCRIPTION
The bug was discovered when doing conversions from a deserialised API Elements tree when using the JSON serialiser as the content for the element internally become undefined which means the serialiser wouldn't work.

Take the following example:

```js
const { ArrayElement } = require('minim');
const { JSON06Serialiser } = require('minim');

const array = new ArrayElement();
const serialiser = new JSON06Serialiser();
console.log(serialiser.serialise(array));

const request = new ArrayElement();
request.element = 'httpRequest';
request.content = undefined;
console.log(serialiser.serialise(request));
```

with incorrectly outputted:

```shell
$ node test.js
{ element: 'array' }
{ element: 'httpRequest' }
```

Whereas the example:

```js
const { ArrayElement } = require('minim');
const { JSON06Serialiser } = require('minim');

const array = new ArrayElement();
const serialiser = new JSON06Serialiser();
console.log(serialiser.serialise(array));

const request = new ArrayElement();
request.element = 'httpRequest';
request.content = undefined;
console.log(serialiser.serialise(request));
```

Correctly outputted:

```shell
$ node test.js
{ element: 'array' }
{ element: 'httpRequest', content: [] }
```