### PR TITLE
Remove toEmbeddedRefract from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,25 +136,6 @@ var ref = element.toRef();
 var ref = element.toRef('attributes');
 ```
 
-#### toEmbeddedRefract
-
-The `toEmbeddedRefract` method returns the Embedded Refract value of the Minim element.
-
-```javascript
-var stringElement = minim.toElement("foobar");
-stringElement.attributes.set('a', 'b');
-var embedded = stringElement.toEmbeddedRefract();
-// Serializes to:
-//
-// {
-//   _refract: {
-//     element: 'string',
-//     attributes: { a: 'b' },
-//     content: 'foobar'
-//   }
-// }
-```
-
 #### equals
 
 Allows for testing equality with the content of the element.


### PR DESCRIPTION
This function has been removed in prior Minim (0.17.0) and was mistakenly left in the documentation which @char0n pointed out in #254.